### PR TITLE
Reduce TriggerActivityMakerPrescale output logging

### DIFF
--- a/src/TriggerActivityMakerPrescale.cpp
+++ b/src/TriggerActivityMakerPrescale.cpp
@@ -20,7 +20,7 @@ TriggerActivityMakerPrescale::operator()(const TriggerPrimitive& input_tp, std::
 {
   if ((m_primitive_count++) % m_prescale == 0)
   {
-    TLOG_DEBUG(TRACE_NAME) << "Emitting prescaled TriggerActivity " << (m_primitive_count-1);
+    TLOG(TLVL_DEBUG_1) << "Emitting prescaled TriggerActivity " << (m_primitive_count-1);
     std::vector<TriggerPrimitive> tp_list;
     tp_list.push_back(input_tp);
     TriggerActivity ta {


### PR DESCRIPTION
Reduce the per-activity log message from DEBUG to DEBUG+1. This is one level more than the per-candidate log message from `TriggerCandidateMakerPrescale`, so at debug level 0 (ie, with `DUNEDAQ_ERS_DEBUG_LEVEL=0`), you see "Emitting TriggerCandidate..." messages, but not "Emitting TriggerActivity...". With debug level 1 or more, you see both.