### PR TITLE
Reduce TRACE logging in a few trigger algs

### DIFF
--- a/src/TriggerActivityMakerADCSimpleWindow.cpp
+++ b/src/TriggerActivityMakerADCSimpleWindow.cpp
@@ -74,7 +74,7 @@ TriggerActivityMakerADCSimpleWindow::configure(const nlohmann::json &config)
 TriggerActivity
 TriggerActivityMakerADCSimpleWindow::construct_ta() const
 {
-  TLOG_DEBUG(TRACE_NAME) << "I am constructing a trigger activity!";
+  TLOG(TLVL_DEBUG_1) << "I am constructing a trigger activity!";
   //TLOG_DEBUG(TRACE_NAME) << m_current_window;
 
   TriggerPrimitive latest_tp_in_window = m_current_window.tp_list.back();

--- a/src/TriggerActivityMakerPrescale.cpp
+++ b/src/TriggerActivityMakerPrescale.cpp
@@ -20,7 +20,7 @@ TriggerActivityMakerPrescale::operator()(const TriggerPrimitive& input_tp, std::
 {
   if ((m_primitive_count++) % m_prescale == 0)
   {
-    TLOG_DEBUG(TRACE_NAME) << "Emitting prescaled TriggerActivity " << (m_primitive_count-1);
+    TLOG(TLVL_DEBUG_1) << "Emitting prescaled TriggerActivity " << (m_primitive_count-1);
     std::vector<TriggerPrimitive> tp_list;
     tp_list.push_back(input_tp);
     TriggerActivity ta {

--- a/src/TriggerCandidateMakerADCSimpleWindow.cpp
+++ b/src/TriggerCandidateMakerADCSimpleWindow.cpp
@@ -25,7 +25,7 @@ TriggerCandidateMakerADCSimpleWindow::operator()(const TriggerActivity& activity
   std::vector<detid_t> detid_vector = {activity.detid};
   std::vector<TriggerActivity> ta_list = {activity};
 
-  TLOG_DEBUG(TRACE_NAME) << "Emitting an ADCSimpleWindow TriggerCandidate " << (m_activity_count-1);
+  TLOG(TLVL_DEBUG_1) << "Emitting an ADCSimpleWindow TriggerCandidate " << (m_activity_count-1);
   TriggerCandidate tc {
       activity.time_start, 
       activity.time_end,  

--- a/src/TriggerCandidateMakerPrescale.cpp
+++ b/src/TriggerCandidateMakerPrescale.cpp
@@ -20,7 +20,7 @@ TriggerCandidateMakerPrescale::operator()(const TriggerActivity& activity, std::
 { 
   if ((m_activity_count++) % m_prescale == 0)
   {
-    TLOG_DEBUG(TRACE_NAME) << "Emitting prescaled TriggerCandidate " << (m_activity_count-1);
+    TLOG(TLVL_DEBUG_1) << "Emitting prescaled TriggerCandidate " << (m_activity_count-1);
     std::vector<detid_t> detid_vector;
     detid_vector.push_back(activity.detid);
     std::vector<TriggerActivity> ta_list;


### PR DESCRIPTION
Phil,
I confirmed that the pre-existing change in TriggerActivityMakerPrescale to reduce the TRACE logging behaved as expected.

I also took the liberty of making similar changes to a few more files in triggeralgs/src.  I confirmed that the code still compiles, and I confirmed that the change to TriggerCandidateMakerPrescale behaves as expected (silent until TRACE level DEBUG+1 is enabled for TriggerCandidateMakerPrescale).

I'm filing this PR to facilitate your review and acceptance of these changes.
Thanks,
Kurt