### PR TITLE
Remove default multiplicity triggering, along with some debugging logs.

### DIFF
--- a/include/triggeralgs/HorizontalMuon/TriggerActivityMakerHorizontalMuon.hpp
+++ b/include/triggeralgs/HorizontalMuon/TriggerActivityMakerHorizontalMuon.hpp
@@ -114,7 +114,7 @@ private:
   // Configurable parameters.
   // triggeractivitymakerhorizontalmuon::ConfParams m_conf;
   bool m_trigger_on_adc = false;
-  bool m_trigger_on_n_channels = true;
+  bool m_trigger_on_n_channels = false;
   bool m_trigger_on_adjacency = true;    // Default use of the horizontal muon triggering
   uint16_t m_adjacency_threshold = 15;   // Default is 15 for trigger
   int m_max_adjacency = 0;               // The maximum adjacency seen so far in any window

--- a/src/TriggerActivityMakerHorizontalMuon.cpp
+++ b/src/TriggerActivityMakerHorizontalMuon.cpp
@@ -77,6 +77,10 @@ TriggerActivityMakerHorizontalMuon::operator()(const TriggerPrimitive& input_tp,
     if (adjacency > m_adjacency_threshold) {
       TLOG(TLVL_DEBUG) << "Emitting adjacency TA with adjacency " << adjacency;
 
+     // Testing Functions
+     //add_window_to_record(m_current_window); // For debugging
+     //dump_window_record(); // For debugging
+
       output_ta.push_back(construct_ta());
       m_current_window.reset(input_tp);
     }

--- a/src/TriggerActivityMakerPrescale.cpp
+++ b/src/TriggerActivityMakerPrescale.cpp
@@ -20,6 +20,7 @@ TriggerActivityMakerPrescale::operator()(const TriggerPrimitive& input_tp, std::
 {
   if ((m_primitive_count++) % m_prescale == 0)
   {
+
     TLOG(TLVL_DEBUG_1) << "Emitting prescaled TriggerActivity " << (m_primitive_count-1);
     std::vector<TriggerPrimitive> tp_list;
     tp_list.push_back(input_tp);

--- a/src/TriggerCandidateMakerHorizontalMuon.cpp
+++ b/src/TriggerCandidateMakerHorizontalMuon.cpp
@@ -31,9 +31,10 @@ TriggerCandidateMakerHorizontalMuon::operator()(const TriggerActivity& activity,
     // If the request has been made to not trigger on number of channels or
     // total adc, simply construct a trigger candidate from any single activity.
     if ((!m_trigger_on_adc) && (!m_trigger_on_n_channels)) {
+
       // add_window_to_record(m_current_window);
       // dump_window_record();
-      TLOG(1) << "Constructing trivial TC.";
+      // TLOG(1) << "Constructing trivial TC.";
 
       TriggerCandidate tc = construct_tc();
       output_tc.push_back(tc);


### PR DESCRIPTION
Removed the log coming from the TCMaker and the default option for triggering on multiplicity (`m_trigger_on_n_channels`) when we only want `m_trigger_on_adjacency` to be set to true in the horizontal muon trigger. This is just some tidying up for using the trigger at cold box tests.