### PR TITLE
Add in specific TCMaker lines for horizontal muon adjacency.

### DIFF
--- a/include/triggeralgs/HorizontalMuon/TriggerCandidateMakerHorizontalMuon.hpp
+++ b/include/triggeralgs/HorizontalMuon/TriggerCandidateMakerHorizontalMuon.hpp
@@ -135,6 +135,7 @@ private:
   // they have not been tested.
   bool m_trigger_on_adc = false;
   bool m_trigger_on_n_channels = false;
+  bool m_trigger_on_adjacency = true;
   uint32_t m_adc_threshold = 1200000;
   uint16_t m_n_channels_threshold = 600; // 80ish for frames, O(200 - 600) for tpslink
   timestamp_t m_window_length = 80000;

--- a/src/TriggerCandidateMakerHorizontalMuon.cpp
+++ b/src/TriggerCandidateMakerHorizontalMuon.cpp
@@ -27,14 +27,16 @@ TriggerCandidateMakerHorizontalMuon::operator()(const TriggerActivity& activity,
   if (m_current_window.is_empty()) {
     m_current_window.reset(activity);
     m_activity_count++;
+
     // Trivial TC Logic:
     // If the request has been made to not trigger on number of channels or
-    // total adc, simply construct a trigger candidate from any single activity.
-    if ((!m_trigger_on_adc) && (!m_trigger_on_n_channels)) {
+    // total adc or the adjacency, simply construct a trigger candidate from
+    // any single activity sent to this TCMaker.
+    if ((!m_trigger_on_adc) && (!m_trigger_on_n_channels) && (!m_trigger_on_adjacency)) {
 
       // add_window_to_record(m_current_window);
       // dump_window_record();
-      // TLOG(1) << "Constructing trivial TC.";
+      TLOG(1) << "Constructing trivial TC.";
 
       TriggerCandidate tc = construct_tc();
       output_tc.push_back(tc);
@@ -54,28 +56,43 @@ TriggerCandidateMakerHorizontalMuon::operator()(const TriggerActivity& activity,
     // TLOG_DEBUG(TRACE_NAME) << "Window not yet complete, adding the activity to the window.";
     m_current_window.add(activity);
   }
+  
   // If the addition of the current TA to the window would make it longer
   // than the specified window length, don't add it but check whether the sum of all adc in
   // the existing window is above the specified threshold. If it is, and we are triggering on ADC,
   // make a TA and start a fresh window with the current TP.
   else if (m_current_window.adc_integral > m_adc_threshold && m_trigger_on_adc) {
-    // TLOG_DEBUG(TRACE_NAME) << "ADC integral in window is greater than specified threshold.";
+    tc_number++;
     TriggerCandidate tc = construct_tc();
-
     output_tc.push_back(tc);
-    // TLOG_DEBUG(TRACE_NAME) << "Resetting window with activity.";
     m_current_window.reset(activity);
+    TLOG(1) << "Constructing ADC TC!";
   }
+  
   // If the addition of the current TA to the window would make it longer
   // than the specified window length, don't add it but check whether the number of hit channels in
   // the existing window is above the specified threshold. If it is, and we are triggering on channels,
   // make a TC and start a fresh window with the current TA.
   else if (m_current_window.n_channels_hit() > m_n_channels_threshold && m_trigger_on_n_channels) {
     tc_number++;
-    //   output_tc.push_back(construct_tc());
+    output_tc.push_back(construct_tc());
     m_current_window.reset(activity);
-    TLOG(1) << "Should not see this!";
+    TLOG(1) << "Constructing multiplicity TC!";
   }
+
+  // If the addition of the current TA to the window would make it longer than the
+  // specified window, don't add it but check whether the adjacency of the activity
+  // meets the required threshold for TCs. If it does, and we're triggering on adjacency
+  // make a TC and start a fresh window of activities with the current TA.
+  
+  // NOTE: Currently triggers trivially if we are triggering on adjacency!
+  else if (m_trigger_on_adjacency) {
+    tc_number++;
+    output_tc.push_back(construct_tc());
+    m_current_window.reset(activity);
+    // TLOG(1) << "Constructing adjacency TC!";
+  }
+
   // If it is not, move the window along.
   else {
     // TLOG_DEBUG(TRACE_NAME) << "Window is at required length but specified threshold not met, shifting window along.";
@@ -96,6 +113,8 @@ TriggerCandidateMakerHorizontalMuon::configure(const nlohmann::json& config)
 {
   // FIX ME: Use some schema here. Also can't work out how to pass booleans.
   if (config.is_object()) {
+    if (config.contains("trigger_on_adjacency"))
+      m_trigger_on_adjacency = config["trigger_on_adjacency"]; // Default is true
     if (config.contains("trigger_on_adc"))
       m_trigger_on_adc = config["trigger_on_adc"];
     if (config.contains("trigger_on_n_channels"))


### PR DESCRIPTION
Currently, the trivial TCMaker logic just creates a TC for any activity passed to the TCMaker whilst `trigger_on_n_channels` and `trigger_on_adc` are **false**. This has been moved to a trivial logic so that we create a TC for any activity whilst `trigger_on_adjacency` is set to **true**.

A default 'trivial' logic still exists in the case that `trigger_on_n_channels`, `trigger_on_adc` and `trigger_on_adjacency`  all get set to **false** by accident. Presumably, this shouldn't happen since if a TA has been received, one of these trigger types should be active.