### PR TITLE
Add readout window ticks before/after to prescale TC maker

### DIFF
--- a/include/triggeralgs/Prescale/TriggerCandidateMakerPrescale.hpp
+++ b/include/triggeralgs/Prescale/TriggerCandidateMakerPrescale.hpp
@@ -27,6 +27,8 @@ private:
 
   uint64_t m_activity_count = 0;    // NOLINT(build/unsigned)
   uint64_t m_prescale = 1;          // NOLINT(build/unsigned)
+  timestamp_t m_readout_window_ticks_before = 0; // How long before the input activity start time to make the candidate start time, in units of clock ticks
+  timestamp_t m_readout_window_ticks_after = 0;  // How long after the input activity end time to make the candidate end time, in units of clock ticks
   
 };
 

--- a/src/TriggerCandidateMakerPrescale.cpp
+++ b/src/TriggerCandidateMakerPrescale.cpp
@@ -26,8 +26,8 @@ TriggerCandidateMakerPrescale::operator()(const TriggerActivity& activity, std::
     ta_list.push_back(static_cast<TriggerActivity::TriggerActivityData>(activity));
     
     TriggerCandidate tc;
-    tc.time_start = activity.time_start;
-    tc.time_end = activity.time_end;
+    tc.time_start = activity.time_start - m_readout_window_ticks_before;
+    tc.time_end = activity.time_end + m_readout_window_ticks_after;
     tc.time_candidate = activity.time_start;
     tc.detid = activity.detid;
     tc.type = TriggerCandidate::Type::kPrescale;
@@ -45,7 +45,12 @@ TriggerCandidateMakerPrescale::configure(const nlohmann::json &config)
   //FIXME use some schema here
   if (config.is_object() && config.contains("prescale"))
   {
-    m_prescale = config["prescale"]; 
+    m_prescale = config["prescale"];
+    if (config.contains("readout_window_ticks_before"))
+      m_readout_window_ticks_before = config["readout_window_ticks_before"];
+    if (config.contains("readout_window_ticks_after"))
+      m_readout_window_ticks_after = config["readout_window_ticks_after"];
+
   }
   TLOG_DEBUG(TRACE_NAME) << "Using candidate prescale " << m_prescale;
 }


### PR DESCRIPTION
Adds options `readout_window_ticks_before` and `readout_window_ticks_after` to `TriggerCandidateMakerPrescale` to set the readout window. MLT currently sets the trigger record readout window for all fragments to the start/end taken from the input TC.