### PR TITLE
Cleaned up code used in the June VD cold box runs

### DIFF
--- a/.github/workflows/auto_approve.yml
+++ b/.github/workflows/auto_approve.yml
@@ -1,0 +1,18 @@
+name: Auto approve
+
+on:
+  workflow_dispatch:
+    inputs: pullRequestNumber
+      description: Pull request number to auto-approve
+      required: false
+
+jobs:
+  auto-approve:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+    - uses: hmarr/auto-approve-action@v2
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        pull-request-number: ${{ github.event.inputs.pullRequestNumber }}

--- a/.github/workflows/auto_approve.yml
+++ b/.github/workflows/auto_approve.yml
@@ -2,9 +2,10 @@ name: Auto approve
 
 on:
   workflow_dispatch:
-    inputs: pullRequestNumber
-      description: Pull request number to auto-approve
-      required: false
+    inputs: 
+      pullRequestNumber:
+        description: Pull request number to auto-approve
+        required: false
 
 jobs:
   auto-approve:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,8 +32,9 @@ add_library(triggeralgs SHARED
   src/TriggerCandidateMakerPrescale.cpp
   src/TriggerActivityMakerSupernova.cpp
   src/TriggerCandidateMakerSupernova.cpp
-  src/TriggerDecisionMakerSupernova.cpp)
-
+  src/TriggerDecisionMakerSupernova.cpp
+  src/TriggerActivityMakerMichelElectron.cpp
+  src/TriggerCandidateMakerMichelElectron.cpp)
 
 target_include_directories(triggeralgs PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>

--- a/include/triggeralgs/MichelElectron/README.md
+++ b/include/triggeralgs/MichelElectron/README.md
@@ -1,0 +1,4 @@
+# HorizontalMuon
+
+ - Coming soon. For now please see https://indico.fnal.gov/event/51502/contributions/226506/attachments/148509/190809/211019_FDDS_HorizontalMuon.pdf
+

--- a/include/triggeralgs/MichelElectron/TriggerActivityMakerMichelElectron.hpp
+++ b/include/triggeralgs/MichelElectron/TriggerActivityMakerMichelElectron.hpp
@@ -127,6 +127,59 @@ private:
   uint16_t ta_channels = 0;
   timestamp_t m_window_length = 50000;
 
+  // Nicholas' Parameters - Required for angle check
+  uint32_t ch_init = 0;
+  int maxadcindex;
+  int maxadcind;
+  uint32_t maxadc =0;
+  uint32_t chnlwid = 0;
+  int64_t timewid=0;
+  int64_t time_window = 0;
+  int64_t minimum_time = 0;
+  int64_t maximum_time = 0;
+  int counting = 0;
+  int trigtot;
+  int64_t TPvol, TPdensity;
+  int time_diff = 30;
+  uint32_t chnl_maxadc;
+  int64_t time_max, this_time_max, prev_time_max, horiz_tt;
+  int64_t temp_t;
+  int64_t time_min, this_time_min, prev_time_min, horiz_tb;
+  float slopecm_scale = 0.04/0.3;
+  bool frontfound = false;
+  bool hitfound = false;
+  int TPcount=0;
+  int braggcnt=0;
+  int chcnt=0;
+  int horiz_noise_cnt = 0;
+  int horiz_tolerance = 8;
+  int tracklen=18;
+  float radTodeg=180/3.14;
+  int64_t y2,y1,y3,y4;
+  uint32_t x2,x1,x3,x4;
+  float bky1,bky2,bky3,bky4, bkpy1,bkpy2,bkpy3,bkpy4;
+  float frontangle_top, frontangle_mid, frontangle_bottom, backangle_top, backangle_mid, backangle_bottom;
+  float slope, frontslope_top, frontslope_mid, frontslope_bottom, backslope_top, backslope_mid, backslope_bottom;
+  int ColPlStartChnl = 2624;
+  int ColPlEndChnl = 2725;
+  int boxchcnt = 1;
+  uint32_t prev_chnl, next_chnl, sf_chnl;
+  int64_t prev_tstart, next_tstart, sf_tstart;
+  int32_t prev_tot, next_tot, sf_tot;
+  int contiguous_tolerance = 16;
+  int tracking_Number = 0;
+  int total_Michels = 0;
+  long total_time_elapsed = 0;
+  std::vector<long> distribution;
+  std::vector<int> tpdistribution;
+
+  std::vector<TriggerPrimitive> tp_for_next_time_window;
+  int64_t boxwidtime= 4500;
+  std::vector<int64_t> timeind_vec;
+  int  boxwidch=96;
+  std::vector<uint32_t> chnlind_vec;
+
+
   // Might not be the best type for this map.
   // std::unordered_map<std::pair<detid_t,channel_t>,channel_t> m_channel_map;
 

--- a/include/triggeralgs/MichelElectron/TriggerActivityMakerMichelElectron.hpp
+++ b/include/triggeralgs/MichelElectron/TriggerActivityMakerMichelElectron.hpp
@@ -1,20 +1,20 @@
 /**
- * @file TriggerActivityMakerHorizontalMuon.hpp
+ * @file TriggerActivityMakerMichelElectron.hpp
  *
  * This is part of the DUNE DAQ Application Framework, copyright 2021.
  * Licensing/copyright details are in the COPYING file that you should have
  * received with this code.
  */
 
-#ifndef TRIGGERALGS_HORIZONTALMUON_TRIGGERACTIVITYMAKERHORIZONTALMUON_HPP_
-#define TRIGGERALGS_HORIZONTALMUON_TRIGGERACTIVITYMAKERHORIZONTALMUON_HPP_
+#ifndef TRIGGERALGS_MICHELELECTRON_TRIGGERACTIVITYMAKERMICHELELECTRON_HPP_
+#define TRIGGERALGS_MICHELELECTRON_TRIGGERACTIVITYMAKERMICHELELECTRON_HPP_
 
 #include "triggeralgs/TriggerActivityMaker.hpp"
 #include <fstream>
 #include <vector>
 
 namespace triggeralgs {
-class TriggerActivityMakerHorizontalMuon : public TriggerActivityMaker
+class TriggerActivityMakerMichelElectron : public TriggerActivityMaker
 {
 
 public:
@@ -139,4 +139,4 @@ private:
 };
 } // namespace triggeralgs
 
-#endif // TRIGGERALGS_HORIZONTALMUON_TRIGGERACTIVITYMAKERHORIZONTALMUON_HPP_
+#endif // TRIGGERALGS_MICHELELECTRON_TRIGGERACTIVITYMAKERMICHELELECTRON_HPP_

--- a/include/triggeralgs/MichelElectron/TriggerActivityMakerMichelElectron.hpp
+++ b/include/triggeralgs/MichelElectron/TriggerActivityMakerMichelElectron.hpp
@@ -116,6 +116,7 @@ private:
   bool m_trigger_on_adc = false;
   bool m_trigger_on_n_channels = false;
   bool m_trigger_on_adjacency = true;    // Default use of the horizontal muon triggering
+  bool debug = false;                    // Use to control whether functions write out useful info
   uint16_t m_adjacency_threshold = 15;   // Default is 15 for trigger
   int m_max_adjacency = 0;               // The maximum adjacency seen so far in any window
   uint32_t m_adc_threshold = 3000000;    // Not currently triggering on this
@@ -134,7 +135,7 @@ private:
   void dump_window_record();
   void dump_tp(TriggerPrimitive const& input_tp);
   void dump_adjacency_channels();  // Essentially a copy of the adjacency checker but dumps chanels to file
-  void check_running_adc(); // Currently just creates a list of running ADC mean for 3 TPs
+  bool check_bragg_peak(); // provides a yes/no answer if the longest track in the window has (potentially) a bragg peak
   std::vector<Window> m_window_record;
 };
 } // namespace triggeralgs

--- a/include/triggeralgs/MichelElectron/TriggerCandidateMakerMichelElectron.hpp
+++ b/include/triggeralgs/MichelElectron/TriggerCandidateMakerMichelElectron.hpp
@@ -1,0 +1,154 @@
+/**
+ * @file TriggerCandidateMakerMichelElectron.hpp
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2021.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#ifndef TRIGGERALGS_MICHELELECTRON_TRIGGERCANDIDATEMAKERMICHELELECTRON_HPP_
+#define TRIGGERALGS_MICHELELECTRON_TRIGGERCANDIDATEMAKERMICHELELECTRON_HPP_
+
+#include "triggeralgs/TriggerCandidateMaker.hpp"
+
+//#include "triggeralgs/triggercandidatemakerhorizontalmuon/Nljs.hpp"
+
+#include <fstream>
+#include <vector>
+
+namespace triggeralgs {
+class TriggerCandidateMakerMichelElectron : public TriggerCandidateMaker
+{
+
+public:
+  /// The function that gets call when there is a new activity
+  void operator()(const TriggerActivity&, std::vector<TriggerCandidate>&);
+
+  void configure(const nlohmann::json& config);
+
+  // void flush(timestamp_t, std::vector<TriggerCandidate>& output_tc);
+
+private:
+  class Window
+  {
+  public:
+    bool is_empty() const { return inputs.empty(); };
+    void add(const TriggerActivity& input_ta)
+    {
+      // Add the input TA's contribution to the total ADC, increase the hit count
+      // of all of the channels which feature and add it to the TA list keeping the TA
+      // list time ordered by time_start. Preserving time order makes moving easier.
+      adc_integral += input_ta.adc_integral;
+      for (TriggerPrimitive tp : input_ta.inputs) {
+        channel_states[tp.channel]++;
+      }
+      // Perform binary search based on time_start.
+      uint16_t insert_at = 0;
+      for (auto ta : inputs) {
+        if (input_ta.time_start < ta.time_start)
+          break;
+        insert_at++;
+      }
+      inputs.insert(inputs.begin() + insert_at, input_ta);
+    };
+    void clear() { inputs.clear(); };
+    uint16_t n_channels_hit() { return channel_states.size(); };
+    void move(TriggerActivity const& input_ta, timestamp_t const& window_length)
+    {
+      // Find all of the TAs in the window that need to be removed
+      // if the input_ta is to be added and the size of the window
+      // is to be conserved.
+      // Subtract those TAs' contribution from the total window ADC and remove their
+      // contributions to the hit counts.
+      uint32_t n_tas_to_erase = 0;
+      for (auto ta : inputs) {
+        if (!(input_ta.time_start - ta.time_start < window_length)) {
+          n_tas_to_erase++;
+          adc_integral -= ta.adc_integral;
+          for (TriggerPrimitive tp : ta.inputs) {
+            channel_states[tp.channel]--;
+            // If a TA being removed from the window results in a channel no longer having
+            // any hits, remove from the states map so map.size() can be used for number
+            // channel hits.
+            if (channel_states[tp.channel] == 0)
+              channel_states.erase(tp.channel);
+          }
+        } else
+          break;
+      }
+      // Erase the TAs from the window.
+      inputs.erase(inputs.begin(), inputs.begin() + n_tas_to_erase);
+      // Make the window start time the start time of what is now the
+      // first TA.
+      if (inputs.size() != 0) {
+        time_start = inputs.front().time_start;
+        add(input_ta);
+      } else
+        add(input_ta);
+    }
+    void reset(TriggerActivity const& input_ta)
+    {
+      // Empty the channel and TA lists.
+      channel_states.clear();
+      inputs.clear();
+      // Set the start time of the window to be the start time of the
+      // input_ta.
+      time_start = input_ta.time_start;
+      // Start the total ADC integral.
+      adc_integral = input_ta.adc_integral;
+      // Start hit count for the hit channels.
+      for (TriggerPrimitive tp : input_ta.inputs) {
+        channel_states[tp.channel]++;
+      }
+      // Add the input TA to the TA list.
+      inputs.push_back(input_ta);
+    }
+    friend std::ostream& operator<<(std::ostream& os, const Window& window)
+    {
+      if (window.is_empty())
+        os << "Window is empty!\n";
+      //      else{
+      //        os << "Window start: " << window.time_start << ", end: " << window.inputs.back().time_start;
+      //        os << ". Total of: " << window.adc_integral << " ADC counts with " << window.inputs.size() << " TPs.\n";
+      //        os << window.channel_states.size() << " independent channels have hits.\n";
+      //      }
+      return os;
+    };
+
+    timestamp_t time_start;
+    uint64_t adc_integral;
+    std::unordered_map<channel_t, uint16_t> channel_states;
+    std::vector<TriggerActivity> inputs;
+  };
+
+  TriggerCandidate construct_tc() const;
+  bool check_adjacency() const;
+
+  Window m_current_window;
+  uint64_t m_activity_count = 0; // NOLINT(build/unsigned)
+
+  // Configurable parameters.
+  // triggercandidatemakerhorizontalmuon::ConfParams m_conf;
+  // If both m_trigger_on_adc and m_trigger_on_n_channels is false, nothing is done at
+  // the candidate level, candidates are made 1 for 1 with activities.
+  // Use any other combination of m_trigger_on_adc and m_trigger_on_n_channels with caution,
+  // they have not been tested.
+  bool m_trigger_on_adc = false;
+  bool m_trigger_on_n_channels = false;
+  uint32_t m_adc_threshold = 1200000;
+  uint16_t m_n_channels_threshold = 600; // 80ish for frames, O(200 - 600) for tpslink
+  timestamp_t m_window_length = 80000;
+  timestamp_t m_readout_window_ticks_before = 30000;
+  timestamp_t m_readout_window_ticks_after = 30000;
+  int tc_number = 0;
+  // Might not be the best type for this map.
+  // std::unordered_map<std::pair<detid_t,channel_t>,channel_t> m_channel_map;
+
+  // For debugging purposes.
+  void add_window_to_record(Window window);
+  void dump_window_record();
+  std::vector<Window> m_window_record;
+};
+} // namespace triggeralgs
+
+#endif // TRIGGERALGS_MICHELELECTRON_TRIGGERCANDIDATEMAKERMICHELELECTRON_HPP_

--- a/src/TriggerActivityMakerADCSimpleWindow.cpp
+++ b/src/TriggerActivityMakerADCSimpleWindow.cpp
@@ -47,6 +47,8 @@ TriggerActivityMakerADCSimpleWindow::operator()(const TriggerPrimitive& input_tp
   else{
     //TLOG_DEBUG(TRACE_NAME) << "Window is at required length but adc threshold not met, shifting window along.";
     m_current_window.move(input_tp, m_window_length);
+    TLOG(1) << "Constructing a TA.";
+    output_ta.push_back(construct_ta());
   }
   
   //TLOG_DEBUG(TRACE_NAME) << m_current_window;

--- a/src/TriggerActivityMakerHorizontalMuon.cpp
+++ b/src/TriggerActivityMakerHorizontalMuon.cpp
@@ -17,8 +17,7 @@ void
 TriggerActivityMakerHorizontalMuon::operator()(const TriggerPrimitive& input_tp,
                                                std::vector<TriggerActivity>& output_ta)
 {
-  if(input_tp.channel > 2623 && input_tp.channel < 3200){
-
+  //if(input_tp.channel > 2623 && input_tp.channel < 3200){
   // 0) FIRST TP =============================================================================================
   // The first time operator() is called, reset the window object.
   if (m_current_window.is_empty()) {
@@ -65,9 +64,9 @@ TriggerActivityMakerHorizontalMuon::operator()(const TriggerPrimitive& input_tp,
   // on adjacency, then create a TA and reset the window with the new/current TP.
   else if (check_adjacency() > m_adjacency_threshold &&  m_trigger_on_adjacency) {
     
-    //auto adjacency = check_adjacency();    
+    auto adjacency = check_adjacency();    
 
-   // TLOG(1) << "Emitting adjacency TA with adjacency " << adjacency;
+    TLOG(1) << "Emitting adjacency TA with adjacency " << adjacency;
     // add_window_to_record(m_current_window); // For debugging
     // dump_window_record(); // For debugging
     // dump_adjacency_channels(); // Function to dump start and end channels of tracks leading to TA
@@ -80,9 +79,8 @@ TriggerActivityMakerHorizontalMuon::operator()(const TriggerPrimitive& input_tp,
   else {
     m_current_window.move(input_tp, m_window_length);
   }
-
   m_primitive_count++;
-  } // End of collection filter
+  //} // End of collection filter
 
   return;
 }
@@ -186,7 +184,6 @@ TriggerActivityMakerHorizontalMuon::check_adjacency() const
     next = (i + 1) % chanList.size(); // Loops back when outside of channel list range
     channel = chanList.at(i);
     next_channel = chanList.at(next); // Next channel with a hit
-    int gap = 5; // Max number of wires to skip before ending count
 
     // End of vector condition
     if (next_channel == 0) {

--- a/src/TriggerActivityMakerMichelElectron.cpp
+++ b/src/TriggerActivityMakerMichelElectron.cpp
@@ -18,7 +18,6 @@ void
 TriggerActivityMakerMichelElectron::operator()(const TriggerPrimitive& input_tp,
                                                std::vector<TriggerActivity>& output_ta)
 {
-  if(input_tp.channel > 2623 && input_tp.channel < 3200){
 
   // The first time operator() is called, reset the window object.
   if (m_current_window.is_empty()) {
@@ -35,12 +34,12 @@ TriggerActivityMakerMichelElectron::operator()(const TriggerPrimitive& input_tp,
 
   // Adjacency Threshold Exceeded ============================================================================
   // We've filled the window, now require a sufficient length track AND that the track has a potential Bragg P.
-  else if (check_adjacency() > m_adjacency_threshold && m_trigger_on_adjacency && check_bragg_peak() ) { 
+  else if (  m_trigger_on_adjacency && check_bragg_peak() ) { 
 
      // Generate a TA with the current window of TPs
      //add_window_to_record(m_current_window);
      //dump_window_record();
-     //TLOG(1) << "Emitting a Michel electron trigger!";
+     TLOG(1) << "Emitting a trigger for candidate Michel event!";
      output_ta.push_back(construct_ta());
      m_current_window.reset(input_tp);
     
@@ -52,7 +51,6 @@ TriggerActivityMakerMichelElectron::operator()(const TriggerPrimitive& input_tp,
   }
 
   m_primitive_count++;
- } // End of collection channel filter
   return;
 }
 
@@ -121,8 +119,8 @@ TriggerActivityMakerMichelElectron::check_adjacency() const
   unsigned int tol_count = 0;
 
   // Start and end channels of track - for debugging function
-  uint16_t s = 1;
-  uint16_t e = 1;
+  //uint16_t s = 1;
+  //uint16_t e = 1;
 
   // Generate a channelID ordered list of hit channels for this window
   std::vector<int> chanList;
@@ -174,6 +172,13 @@ TriggerActivityMakerMichelElectron::check_adjacency() const
       ++tol_count;
       ++tol_count;
     }
+    else if ((next_channel == channel + 5) && (tol_count < m_adj_tolerance)) {
+      ++adj;
+      ++tol_count;
+      ++tol_count;
+      ++tol_count;
+      ++tol_count;
+    }  
 
     // If next hit isn't within our reach, end adj count and check for a new max
     else {
@@ -255,7 +260,7 @@ TriggerActivityMakerMichelElectron::check_bragg_peak()
     uint32_t adc_peak;
   };
   
-  std::vector<hit> chanList;  // Full list of unique channels with hits
+  std::vector<hit> chanList;  // Full list of unique channels with hits - I don't think this is actually unique hits?
   std::vector<hit> trackHits; // List of all hits that contribute to the track/adjacency (incs same channel hits)
   std::vector<hit> finalHits; // Final list of hits that make up track, use at end.
   for (auto tp : m_current_window.inputs) {
@@ -371,6 +376,11 @@ TriggerActivityMakerMichelElectron::check_bragg_peak()
   // We now have a vector containing all the hits of a 'track' or above-threshold adjacency. Use these
   // to check for a BP.
   
+  // If we have exceeded the required track length, then proceed to look for a large charge dump at one end of the track and 2 kinks
+  if (max > m_adjacency_threshold){ // Here is the adjacency check now.
+  
+
+  // BRAG PEAK SEACH ==============================================================
   std::vector<float> adc_means_list;
   uint16_t convolve_value = 8;
 
@@ -390,9 +400,9 @@ TriggerActivityMakerMichelElectron::check_bragg_peak()
     adc_sum = 0;
   } 
 
-  // We now have 1 lists of means, for different parameters. We continue with just one here, choosing 8.
+  // We now have a list of adc means, for different parameters. 
   float ped = std::accumulate(adc_means_list.begin(), adc_means_list.end(), 0.0) / adc_means_list.size();
-  float tot_adc = std::accumulate(adc_means_list.begin(), adc_means_list.end(), 0.0);
+  //float tot_adc = std::accumulate(adc_means_list.begin(), adc_means_list.end(), 0.0);
   float charge = 0;
   std::vector<float> charge_dumps; // Add clusters of charge here
 
@@ -410,285 +420,59 @@ TriggerActivityMakerMichelElectron::check_bragg_peak()
   // If the maximum of that list of charge dumps is near(at?) either end of it, proceed to angle check.
   float max_charge = *max_element(charge_dumps.begin(), charge_dumps.end()); 
 
-  // If the highest cluster of charge is at either end of the track, then signal potential BP
+  // If the highest cluster of charge is at either end of the charge dump vector, potential brag peak and look for two kinks
   if(max_charge == charge_dumps.front() || max == charge_dumps.back()){
-    
-    // NICHOLAS' CODE STARTS HERE ==========================================================================
-    // =====================================================================================================
-    //TLOG(1) << "Nicholas' code starting here";
 
-    // required parameters, can change these to config later if we want
-    int bragg_peak_threshold = 3000;
-    int tracklength = 18;
-    float kink_angle = 30;
+    bool ghostKink = false; // Required to be at earliest part of track - necessarily changes gradient sign
+    bool kink2 = false;  // this is the second kink, that DOES NOT necessarily have a dG sign change
+    std::vector<float> runningGradient;
+    std::vector<float> runningMeanGradient;
 
-    // Do we really need all these?
-    std::vector<hit> pre_tp_list;
-    std::vector<hit> tp_list;
-    std::vector<hit> tp_list_time_shifted;
-    std::vector<hit> tp_only;
-    std::vector<hit> tp_list_maxadc;
-    std::vector<hit> tp_list_this;
-    std::vector<hit> tp_list_prev;
-    std::vector<hit> tp_list_next;
-    std::vector<hit> tp_list_sf;
-    std::vector<hit> tp_list_sb;
-    std::vector<hit> tmpchnl_vec;
-    std::vector<hit> sublist;
-    std::vector<hit> final_tp_list;
-    std::vector<int>  maxadcindex_vec;
-    std::vector<uint32_t> initialvec_adc;
-    std::vector<hit> test;
-
-
-    // sort by time and convert to 2MHz clock
+    // sort hits by time to find time shift
     std::sort(finalHits.begin(), finalHits.end(), [](hit a, hit b) { return a.startTime < b.startTime; });
-    // sort by time and convert to 2MHz clock 
-    int64_t shift = finalHits[0].startTime;
-    for(int i=0; i<finalHits.size();i++){
-	finalHits[i].startTime  = (finalHits[i].startTime - shift)/25;
-	finalHits[i].tot = finalHits[i].tot/25;
+    //int64_t shift = finalHits[0].startTime;
+    // DO NOT sort back to channel order - the reverse of a track later will cause divisions of huge gaps in time
+    //std::sort(finalHits.begin(), finalHits.end(), [](hit a, hit b) { return a.chan < b.chan; });
+
+    // Populate the runningGradient with the track hits. this is in time order now
+    for (int i=0 ; i < finalHits.size(); i++){
+    
+      // End of track condition
+      if (i+1 == finalHits.size()){ 
+        break; } // just stop adding gradients, can do something nicer here later
+    
+      // Skip same channel hits or if the start times are the same - no div by zero! 
+      if (finalHits.at(i+1).chan == finalHits.at(i).chan || (finalHits.at(i+1).startTime == finalHits.at(i).startTime) ) { continue; } //try next one!
+      // grad is just small z distance change over small x distance change, values converted roughly! 
+      float g = ((finalHits.at(i+1).chan - finalHits.at(i).chan)*4.67)/((finalHits.at(i+1).startTime - finalHits.at(i).startTime)*2e-5*1400);
+      runningGradient.push_back(g); 
     }
-
-    // sort back by channel
-    std::sort(finalHits.begin(), finalHits.end(), [](hit a, hit b) { return a.chan < b.chan; }); 
-
-    // bragg peak = TP with highest adc
-    uint32_t max_adc_integral = 0;
-    for(int i=0; i<finalHits.size(); i++){
-      if (finalHits[i].adc > max_adc_integral){
-    	  max_adc_integral = finalHits[i].adc;
-    	  maxadcindex = i;
+  
+    if ( runningGradient.size() > 10 ){
+    // Now lets take a running mean of the gradients between TPs, less susceptible to wild changes due to deltas/etc
+    for(int g=0 ; g < runningGradient.size() ; g++){
+      float gsum = 0;
+      for(int j = g ; j < 3+g ; j++){
+         if(g == runningGradient.size()-2) { break; } // Just skip the end of vector condition for now
+         gsum += runningGradient.at(g);
       }
+      runningMeanGradient.push_back(gsum/3);
     }
-
-    // make vector of (a single?) hit
-    std::vector<hit> finalHits_maxadc;
-    if (max_adc_integral > bragg_peak_threshold){
-    	finalHits_maxadc.push_back(finalHits[maxadcindex]);
-    }
-
-    // no candidate? end the check here and assign michel = false
-    else { michel = false; return 0; }
-
-    // is this a stopping muon? 
-    for (int imaxadc=0; imaxadc<finalHits_maxadc.size(); imaxadc++){
-      chnl_maxadc = finalHits_maxadc[imaxadc].chan;
-      time_max = finalHits_maxadc[imaxadc].startTime + finalHits_maxadc[imaxadc].tot;
-      time_min = finalHits_maxadc[imaxadc].startTime;
-
-      // initialise some required variables, not we are looping through the max ADC TP
-      hit tp_this = {finalHits_maxadc[imaxadc].chan, finalHits_maxadc[imaxadc].startTime, finalHits_maxadc[imaxadc].adc,
-      finalHits_maxadc[imaxadc].tot, finalHits_maxadc[imaxadc].adc_peak };
-      tp_list_this.push_back(tp_this); // Making a list of high ADC TPs?
-      tp_list_prev = tp_list_this;
-      tp_list_next = tp_list_this;
-      tp_list_sf = tp_list_this;
-      tp_list_sb = tp_list_this;
-      // initialise
-      frontfound = false;
-      hitfound = false;
-      braggcnt=0;
-      slope = 0;
-      horiz_noise_cnt = 0;
-      frontslope_top = 0;
-      backslope_top = 0;
-      frontslope_mid = 0;
-      backslope_mid = 0;
-      frontslope_bottom = 0;
-      backslope_bottom = 0;
-      frontangle_top = 0;
-      frontangle_mid = 0;
-      frontangle_bottom = 0;
-      backangle_top=0;
-      backangle_mid=0;
-      backangle_bottom=0;
-      horiz_tb = 0;
-      horiz_tt = 0;
-      
-      //Analyzing Forward Channels
-      for (int icheck=maxadcindex; icheck<finalHits.size(); icheck++) {
-
-	//If we've found a front, we move on to the second part of the code
-	if (frontfound == true){ break; }
-
-	//If current icheck loop is in channel two channels away either from channel 
-        //with max adc or channel next to maxadc channel based on if we find hit in 
-        //next channel (right next to chnl with max adc)
-	if(finalHits[icheck].chan >= (chnl_maxadc+2)){
-	  chnl_maxadc = tp_list_next[imaxadc].chan;
-	  if (hitfound == false) break;
-	  if (hitfound == true){
-	    braggcnt+=1;
-	    //This is for the clope calculation later
-	    if (braggcnt==3){
-	      tp_list_sf = tp_list_next;
-	    }
-
-            //We have detected enough hits along a track to calculate a slope
-	    if (braggcnt >= tracklength/2){
-	      frontfound = true;
-	      int denf = (tp_list_next[imaxadc].chan - tp_list_sf[imaxadc].chan);
-	      if (denf!=0){
-	        frontslope_top = float(tp_list_next[imaxadc].startTime + tp_list_next[imaxadc].tot - tp_list_sf[imaxadc].startTime - tp_list_sf[imaxadc].tot)/ denf;
-	        frontslope_mid = float(tp_list_next[imaxadc].startTime + (tp_list_next[imaxadc].tot)/2 -tp_list_sf[imaxadc].startTime - (tp_list_sf[imaxadc].tot)/2)/ denf ;
-	        frontslope_bottom = float(tp_list_next[imaxadc].startTime - tp_list_sf[imaxadc].startTime)/ denf;
-	      }
-	    }
-            tp_list_prev = tp_list_next;
-          }
-
-	  hitfound = false;
-          this_time_max = 0;
-	  this_time_min = 0;
-          prev_time_max = 0;
-	  prev_time_min = 0;
-         }
-
-	  //Checking the time condition for proximity
-	  if((finalHits[icheck].chan == (chnl_maxadc+1)) or (finalHits[icheck].chan == (chnl_maxadc+2)) or 
-            (finalHits[icheck].chan == (chnl_maxadc+3)) or (finalHits[icheck].chan == (chnl_maxadc+4))){
-
-	    this_time_max = finalHits[icheck].startTime + finalHits[icheck].tot;
-	    this_time_min =  finalHits[icheck].startTime;
-	    prev_time_max = tp_list_prev[imaxadc].startTime + tp_list_prev[imaxadc].tot;
-	    prev_time_min =tp_list_prev[imaxadc].startTime;
-
-	   if ((this_time_min>=prev_time_min and this_time_min<=prev_time_max) or (this_time_max>=prev_time_min and this_time_max<=prev_time_max) or (prev_time_max<=this_time_max and prev_time_min>=this_time_min) ){
-	            
-	      if (horiz_noise_cnt == 0){
-		horiz_tb = prev_time_min;
-		horiz_tt = prev_time_max;
-	      }
-
-	      hitfound = true;
-	      tp_list_next[imaxadc].chan = finalHits[icheck].chan;
-	      tp_list_next[imaxadc].startTime = finalHits[icheck].startTime;
-	      tp_list_next[imaxadc].adc = finalHits[icheck].adc;
-	      tp_list_next[imaxadc].adc_peak = finalHits[icheck].adc_peak;
-	      tp_list_next[imaxadc].tot = finalHits[icheck].tot;
-
-	      if (abs(this_time_min - horiz_tb) <=1 or abs(this_time_max - horiz_tt) <=1){
-		horiz_noise_cnt+=1;
-		if (horiz_noise_cnt>horiz_tolerance) break;
-	      }
-	      else{horiz_noise_cnt = 0; }
-		 
-	      if (this_time_max > time_max) time_max = this_time_max;
-	      if (this_time_min < time_min) time_min = this_time_min;
-	    }
-	  }
-        }
-
-     //reset variables for backwards channels
-     chnl_maxadc = finalHits_maxadc[imaxadc].chan;
-     tp_list_prev = tp_list_this;
-     tp_list_next = tp_list_this;
-     this_time_max =0;
-     this_time_min =0;
-     prev_time_max = 0;
-     prev_time_min =0;
-     slope=0;
-     hitfound = false;
-            
-     // Looking at Backwards channels
-     if (frontfound == true){
-       for (int icheckb=maxadcindex; icheckb>=0; icheckb--){
-	 if(finalHits[icheckb].chan <= (chnl_maxadc-2)){
-	     chnl_maxadc = tp_list_next[imaxadc].chan;
-	     if (hitfound == false) break;
-	     if (hitfound == true) {
-	       braggcnt+=1;
-	       if (braggcnt == (tracklength/2)+3){ tp_list_sb = tp_list_next;}
-	       if (braggcnt >= tracklength){
-	         bky1=tp_list_next[imaxadc].startTime;
-	         bky2=tp_list_next[imaxadc].tot;
-	         bky3=tp_list_sb[imaxadc].startTime;
-	         bky4=tp_list_sb[imaxadc].tot;
-
-	         float num = float(bky1+bky2-(bky3+bky4));
-	         int den = (tp_list_next[imaxadc].chan - tp_list_sb[imaxadc].chan);
-	         if(den!=0){
-	           backslope_top = (bky1+bky2-(bky3+bky4)) / den;
-	           backslope_mid = (bky1+(bky2/2)-(bky3+(bky4/2))) / den;
-	           backslope_bottom = (bky1-bky3) / den;
-
-	           frontangle_top = (atan(slopecm_scale*float(frontslope_top)))*radTodeg;
-	           backangle_top = (atan(slopecm_scale*float(backslope_top)))*radTodeg;
-	           frontangle_mid = (atan(slopecm_scale*float(frontslope_mid)))*radTodeg;
-	           backangle_mid = (atan(slopecm_scale*float(backslope_mid)))*radTodeg;
-	           frontangle_bottom = (atan(slopecm_scale*float(frontslope_bottom)))*radTodeg;
-	           backangle_bottom = (atan(slopecm_scale*float(backslope_bottom)))*radTodeg;   
-
-	           
-                   TLOG(1) << "Made it to the angle calculation stage.";
-                   //Changed Angle from 30 to 50 
-	           if (abs(frontangle_mid-backangle_mid)>kink_angle or abs(frontangle_top-backangle_top)>kink_angle or abs(frontangle_bottom-backangle_bottom)>kink_angle){
-	              michel=true;
-	              hit tp_final {finalHits_maxadc[imaxadc].chan, finalHits_maxadc[imaxadc].startTime, finalHits_maxadc[imaxadc].adc, finalHits_maxadc[imaxadc].tot, finalHits_maxadc[imaxadc].adc_peak};
-	              final_tp_list.push_back(tp_final);
-	               return 1;
-	           }
-	          else {
-	             return 0;
-	          }
-	        }
-               }
-
-	       tp_list_prev = tp_list_next;
-	      }
-
-	  hitfound = false;
-	  this_time_max = 0;
-	  this_time_min = 0;
-	  prev_time_max = 0;
-	  prev_time_min = 0;
-	 }
-
-	 if( (finalHits[icheckb].chan == (chnl_maxadc-1)) or  (finalHits[icheckb].chan == (chnl_maxadc-2)) or (finalHits[icheckb].chan == (chnl_maxadc-3)) or (finalHits[icheckb].chan == (chnl_maxadc-4)) ){
-	        this_time_max = finalHits[icheckb].startTime + finalHits[icheckb].tot;
-	        this_time_min =  finalHits[icheckb].startTime;
-	        prev_time_max = tp_list_prev[imaxadc].startTime + tp_list_prev[imaxadc].tot;
-	        prev_time_min =tp_list_prev[imaxadc].startTime;
-
-	        if ((this_time_min>=prev_time_min and this_time_min<=prev_time_max) or (this_time_max>=prev_time_min and this_time_max<=prev_time_max) or (prev_time_max<=this_time_max and prev_time_min>=this_time_min) ) {
-	          if (horiz_noise_cnt == 0){
-	              horiz_tb = prev_time_min;
-	                    horiz_tt = prev_time_max;
-	            }
-	          hitfound = true;
-
-	          tp_list_next[imaxadc].chan = finalHits[icheckb].chan;
-	          tp_list_next[imaxadc].startTime = finalHits[icheckb].startTime;
-	          tp_list_next[imaxadc].adc = finalHits[icheckb].adc;
-	          tp_list_next[imaxadc].adc_peak = finalHits[icheckb].adc_peak;
-	          tp_list_next[imaxadc].tot = finalHits[icheckb].tot;
-
-	          if (abs(this_time_min - horiz_tb) <=1 or abs(this_time_max - horiz_tt) <=1){
-	            horiz_noise_cnt+=1;
-	            if (horiz_noise_cnt>horiz_tolerance) break;
-	          }
-	          else{
-	            horiz_noise_cnt = 0;
-	          }
-	          if (this_time_max > time_max) time_max = this_time_max;
-	          if (this_time_min < time_min) time_min = this_time_min;
-	          }
-	      }
-	    }
-	  }// if front found clause   
-    } // End of loop over max ADC hits, not sure we should be looping here, there's only one? 
-    //TLOG(1) << "Nicholas' code ending here";
-    // NICHOLAS' CODE ENDS HERE ===========================================================================
-    // ====================================================================================================
-    // HAVE YOU SET michel BOOL?
-  }
-
-
+   
+    // We have a list of gradients, now just demand that the two ends have gradients that differ significantly
+    // from the mean at both ends. This should pick out wesKinks and michelKinks
+    if(runningMeanGradient.size() > 10 ){
+      int end = runningMeanGradient.size();
+    float ped = (std::abs(std::accumulate(runningMeanGradient.begin(), runningMeanGradient.end(), 0.0)))/(runningMeanGradient.size());
+    if((std::abs(runningMeanGradient.front()) + ped > 4*ped)  &&  ((std::abs(runningMeanGradient.back() + ped)) > 4*ped)){
+      michel = true;
+    }   
+    } // Requres mean gradients list to be a decent size
+    } // Require gradients list to be greater than 2...
 
   // This 'debug' is a switch I use once inside the check in operator() - It shouldn't be used
   // at the condition stage! Tidy this up when Michel trigger is complete.
-  if(debug){
+  /*if(debug){
     // Output the start and end channel of this window to the debugging file
     std::ofstream outfile;
     outfile.open("adjacnecy_start_end_tps.csv", std::ios_base::app);
@@ -704,7 +488,9 @@ TriggerActivityMakerMichelElectron::check_bragg_peak()
     }
     outfile2.close(); 
     }
-   
+  }*/
+  }
+ } // ADJACENCY THRESHOLD CONDITION
   // HAVE YOU SET MICHEL? 
   return michel;
 }

--- a/src/TriggerActivityMakerPrescale.cpp
+++ b/src/TriggerActivityMakerPrescale.cpp
@@ -21,7 +21,7 @@ TriggerActivityMakerPrescale::operator()(const TriggerPrimitive& input_tp, std::
   if ((m_primitive_count++) % m_prescale == 0)
   {
 
-    TLOG(TLVL_DEBUG_1) << "Emitting prescaled TriggerActivity " << (m_primitive_count-1);
+    TLOG(1) << "Emitting prescaled TriggerActivity " << (m_primitive_count-1);
     std::vector<TriggerPrimitive> tp_list;
     tp_list.push_back(input_tp);
 

--- a/src/TriggerCandidateMakerHorizontalMuon.cpp
+++ b/src/TriggerCandidateMakerHorizontalMuon.cpp
@@ -34,8 +34,8 @@ TriggerCandidateMakerHorizontalMuon::operator()(const TriggerActivity& activity,
 
       // add_window_to_record(m_current_window);
       // dump_window_record();
-      // TLOG(1) << "Constructing trivial TC.";
-
+      TLOG(1) << "Constructing trivial TC.";
+      TLOG(1) << "Activity count: " << m_activity_count;
       TriggerCandidate tc = construct_tc();
       output_tc.push_back(tc);
 

--- a/src/TriggerCandidateMakerMichelElectron.cpp
+++ b/src/TriggerCandidateMakerMichelElectron.cpp
@@ -1,0 +1,221 @@
+/**
+ * @file TriggerCandidateMakerMichelElectron.cpp
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2021.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#include "triggeralgs/MichelElectron/TriggerCandidateMakerMichelElectron.hpp"
+
+#include "TRACE/trace.h"
+#define TRACE_NAME "TriggerCandidateMakerMichelElectron"
+
+#include <vector>
+
+using namespace triggeralgs;
+
+void
+TriggerCandidateMakerMichelElectron::operator()(const TriggerActivity& activity,
+                                                std::vector<TriggerCandidate>& output_tc)
+{
+
+  std::vector<TriggerActivity::TriggerActivityData> ta_list = { static_cast<TriggerActivity::TriggerActivityData>(
+    activity) };
+
+  // The first time operator is called, reset window object.
+  if (m_current_window.is_empty()) {
+    m_current_window.reset(activity);
+    m_activity_count++;
+    // Trivial TC Logic:
+    // If the request has been made to not trigger on number of channels or
+    // total adc, simply construct a trigger candidate from any single activity.
+    if ((!m_trigger_on_adc) && (!m_trigger_on_n_channels)) {
+
+      // add_window_to_record(m_current_window);
+      // dump_window_record();
+      // TLOG(1) << "Constructing trivial TC.";
+
+      TriggerCandidate tc = construct_tc();
+      output_tc.push_back(tc);
+
+      // Clear the current window (only has a single TA in it)
+      m_current_window.clear();
+    }
+    return;
+  }
+
+  // FIX ME: Only want to call this if running in debug mode.
+  // add_window_to_record(m_current_window);
+
+  // If the difference between the current TA's start time and the start of the window
+  // is less than the specified window size, add the TA to the window.
+  if ((activity.time_start - m_current_window.time_start) < m_window_length) {
+    // TLOG_DEBUG(TRACE_NAME) << "Window not yet complete, adding the activity to the window.";
+    m_current_window.add(activity);
+  }
+  // If the addition of the current TA to the window would make it longer
+  // than the specified window length, don't add it but check whether the sum of all adc in
+  // the existing window is above the specified threshold. If it is, and we are triggering on ADC,
+  // make a TA and start a fresh window with the current TP.
+  else if (m_current_window.adc_integral > m_adc_threshold && m_trigger_on_adc) {
+    // TLOG_DEBUG(TRACE_NAME) << "ADC integral in window is greater than specified threshold.";
+    TriggerCandidate tc = construct_tc();
+
+    output_tc.push_back(tc);
+    // TLOG_DEBUG(TRACE_NAME) << "Resetting window with activity.";
+    m_current_window.reset(activity);
+  }
+  // If the addition of the current TA to the window would make it longer
+  // than the specified window length, don't add it but check whether the number of hit channels in
+  // the existing window is above the specified threshold. If it is, and we are triggering on channels,
+  // make a TC and start a fresh window with the current TA.
+  else if (m_current_window.n_channels_hit() > m_n_channels_threshold && m_trigger_on_n_channels) {
+    tc_number++;
+    //   output_tc.push_back(construct_tc());
+    m_current_window.reset(activity);
+    TLOG(1) << "Should not see this!";
+  }
+  // If it is not, move the window along.
+  else {
+    // TLOG_DEBUG(TRACE_NAME) << "Window is at required length but specified threshold not met, shifting window along.";
+    m_current_window.move(activity, m_window_length);
+  }
+
+  // TLOG_DEBUG(TRACE_NAME) << m_current_window;
+
+  m_activity_count++;
+
+  //  if(m_activity_count % 500 == 0) dump_window_record();
+
+  return;
+}
+
+void
+TriggerCandidateMakerMichelElectron::configure(const nlohmann::json& config)
+{
+  // FIX ME: Use some schema here. Also can't work out how to pass booleans.
+  if (config.is_object()) {
+    if (config.contains("trigger_on_adc"))
+      m_trigger_on_adc = config["trigger_on_adc"];
+    if (config.contains("trigger_on_n_channels"))
+      m_trigger_on_n_channels = config["trigger_on_n_channels"];
+    if (config.contains("adc_threshold"))
+      m_adc_threshold = config["adc_threshold"];
+    if (config.contains("n_channels_threshold"))
+      m_n_channels_threshold = config["n_channels_threshold"];
+    if (config.contains("window_length"))
+      m_window_length = config["window_length"];
+    if (config.contains("readout_window_ticks_before"))
+      m_readout_window_ticks_before = config["readout_window_ticks_before"];
+    if (config.contains("readout_window_ticks_after"))
+      m_readout_window_ticks_after = config["readout_window_ticks_after"];
+
+    // if (config.contains("channel_map")) m_channel_map = config["channel_map"];
+  }
+  /*if(m_trigger_on_adc) {
+    TLOG_DEBUG(TRACE_NAME) << "If the total ADC of trigger activities with times within a "
+                           << m_window_length << " tick time window is above " << m_adc_threshold << " counts, a trigger
+  will be issued.";
+  }
+  else if(m_trigger_on_n_channels) {
+    TLOG_DEBUG(TRACE_NAME) << "If the total number of channels with hits within a "
+                           << m_window_length << " tick time window is above " << m_n_channels_threshold << " channels,
+  a trigger will be issued.";
+  }
+  else if ((!m_trigger_on_adc) && (!m_trigger_on_n_channels)) {
+    TLOG_DEBUG(TRACE_NAME) << "The candidate maker will construct candidates 1 for 1 from trigger activities.";
+  }
+  else if (m_trigger_on_adc && m_trigger_on_n_channels) {
+    TLOG() << "You have requsted to trigger on both the number of channels hit and the sum of adc counts, "
+           << "unfortunately this is not yet supported. Exiting.";
+    // FIX ME: Logic to throw an exception here.
+  }*/
+
+  return;
+}
+
+TriggerCandidate
+TriggerCandidateMakerMichelElectron::construct_tc() const
+{
+  TriggerActivity latest_ta_in_window = m_current_window.inputs.back();
+
+  TriggerCandidate tc;
+  tc.time_start = m_current_window.time_start - m_readout_window_ticks_before;
+  tc.time_end =
+    latest_ta_in_window.inputs.back().time_start + latest_ta_in_window.inputs.back().time_over_threshold + m_readout_window_ticks_after;
+  tc.time_candidate = m_current_window.time_start;
+  tc.detid = latest_ta_in_window.detid;
+  tc.type = TriggerCandidate::Type::kMichelElectron;
+  tc.algorithm = TriggerCandidate::Algorithm::kMichelElectron;
+
+  // Take the list of triggeralgs::TriggerActivity in the current
+  // window and convert them (implicitly) to detdataformats'
+  // TriggerActivityData, which is the base class of TriggerActivity
+  for (auto& ta : m_current_window.inputs) {
+    tc.inputs.push_back(ta);
+  }
+
+  return tc;
+}
+
+bool
+TriggerCandidateMakerMichelElectron::check_adjacency() const
+{
+  // FIX ME: An adjacency check on the channels which have hits.
+  return true;
+}
+
+// Functions below this line are for debugging purposes.
+void
+TriggerCandidateMakerMichelElectron::add_window_to_record(Window window)
+{
+  m_window_record.push_back(window);
+  return;
+}
+
+void
+TriggerCandidateMakerMichelElectron::dump_window_record()
+{
+  // FIX ME: Need to index this outfile in the name by detid or something similar.
+  std::ofstream outfile;
+  outfile.open("window_record_tcm.csv", std::ios_base::app);
+
+  for (auto window : m_window_record) {
+    outfile << window.time_start << ",";
+    outfile << window.inputs.back().time_start << ",";
+    outfile << window.inputs.back().time_start - window.time_start << ",";
+    outfile << window.adc_integral << ",";
+    outfile << window.n_channels_hit() << ",";
+    outfile << window.inputs.size() << std::endl;
+  }
+
+  outfile.close();
+
+  m_window_record.clear();
+
+  return;
+}
+
+/*
+void
+TriggerCandidateMakerMichelElectron::flush(timestamp_t, std::vector<TriggerCandidate>& output_tc)
+{
+  // Check the status of the current window, construct TC if conditions are met. Regardless
+  // of whether the conditions are met, reset the window.
+  if(m_current_window.adc_integral > m_adc_threshold && m_trigger_on_adc){
+  //else if(m_current_window.adc_integral > m_conf.adc_threshold && m_conf.trigger_on_adc){
+    //TLOG_DEBUG(TRACE_NAME) << "ADC integral in window is greater than specified threshold.";
+    output_tc.push_back(construct_tc());
+  }
+  else if(m_current_window.n_channels_hit() > m_n_channels_threshold && m_trigger_on_n_channels){
+  //else if(m_current_window.n_channels_hit() > m_conf.n_channels_threshold && m_conf.trigger_on_n_channels){
+    //TLOG_DEBUG(TRACE_NAME) << "Number of channels hit in the window is greater than specified threshold.";
+    output_tc.push_back(construct_tc());
+  }
+
+  //TLOG_DEBUG(TRACE_NAME) << "Clearing the current window, on the arrival of the next input_tp, the window will be
+reset."; m_current_window.clear();
+
+  return;
+}*/

--- a/src/TriggerCandidateMakerPrescale.cpp
+++ b/src/TriggerCandidateMakerPrescale.cpp
@@ -20,7 +20,7 @@ TriggerCandidateMakerPrescale::operator()(const TriggerActivity& activity, std::
 { 
   if ((m_activity_count++) % m_prescale == 0)
   {
-    TLOG(TLVL_DEBUG_1) << "Emitting prescaled TriggerCandidate " << (m_activity_count-1);
+    TLOG(1) << "Emitting prescaled TriggerCandidate " << (m_activity_count-1);
 
     std::vector<TriggerActivity::TriggerActivityData> ta_list;
     ta_list.push_back(static_cast<TriggerActivity::TriggerActivityData>(activity));


### PR DESCRIPTION
The Michel algorithm has been largely cleared, particularly of the angle checking code that seemed to be causing tardy outputs, resulting in a failure to trigger efficiently and write TRs. Many logs cleared but everything else the same. This should be a snapshot of the working code for the June cold box runs.

Notes on running:

1. To run these algorithms, the `cardinality` variable must be set in the `trigger_conf.json` to the actual number of links seen by trigger, and not to the expected 7 for the cold box setup. _Not_ setting this correctly will not allow any data to stream through the system until the `stop` command is issued. Phil's PR 134 provides some insight here.

2. In addition, the DQM analysis work must be disabled during a run to prevent a segmentation fault from there. This actually stops the system being able to write out TRs, for what reason I'm not sure. Perhaps because there is some connection between  DQM and DF?