### PR TITLE
Add DBSCAN trigger activity algorithm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,12 @@ project(triggeralgs VERSION 0.3.0)
 
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+add_compile_options(-O2 -march=native -flto)
+
 set(CMAKE_INSTALL_CMAKEDIR   ${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}/cmake )
 
 find_package(nlohmann_json REQUIRED)
@@ -29,7 +35,11 @@ add_library(triggeralgs SHARED
   src/TriggerCandidateMakerPrescale.cpp
   src/TriggerActivityMakerSupernova.cpp
   src/TriggerCandidateMakerSupernova.cpp
-  src/TriggerDecisionMakerSupernova.cpp)
+  src/TriggerDecisionMakerSupernova.cpp
+  src/TriggerActivityMakerDBSCAN.cpp
+  src/dbscan/dbscan.cpp
+  src/dbscan/Hit.cpp
+  )
 target_include_directories(triggeralgs PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>

--- a/include/triggeralgs/TriggerActivity.hpp
+++ b/include/triggeralgs/TriggerActivity.hpp
@@ -29,7 +29,8 @@ struct TriggerActivity
     kUnknown = 0,
     kSupernova = 1,
     kPrescale = 2,
-    kADCSimpleWindow = 3
+    kADCSimpleWindow = 3,
+    kDBSCAN = 4,
   };
 
   timestamp_t time_start = INVALID_TIMESTAMP;

--- a/include/triggeralgs/dbscan/TriggerActivityMakerDBSCAN.hpp
+++ b/include/triggeralgs/dbscan/TriggerActivityMakerDBSCAN.hpp
@@ -1,0 +1,37 @@
+/**
+ * @file TriggerActivityMakerDBSCAN.hpp
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#ifndef TRIGGERALGS_DBSCAN_TRIGGERACTIVITYMAKERDBSCAN_HPP_
+#define TRIGGERALGS_DBSCAN_TRIGGERACTIVITYMAKERDBSCAN_HPP_
+
+#include "triggeralgs/TriggerActivityMaker.hpp"
+#include "dbscan/dbscan.hpp"
+
+#include <memory>
+#include <vector>
+
+namespace triggeralgs {
+class TriggerActivityMakerDBSCAN : public TriggerActivityMaker
+{
+
+public:
+  void operator()(const TriggerPrimitive& input_tp, std::vector<TriggerActivity>& output_ta);
+  
+  void configure(const nlohmann::json &config);
+  
+private:  
+  int m_min_pts; // Minimum number of points to form a cluster
+  timestamp_t m_first_timestamp{0};
+  timestamp_t m_prev_timestamp{0};
+  std::vector<dbscan::Cluster> m_dbscan_clusters;
+  std::unique_ptr<dbscan::IncrementalDBSCAN> m_dbscan;
+  
+};
+} // namespace triggeralgs
+
+#endif // TRIGGERALGS_PRESCALE_TRIGGERACTIVITYMAKERPRESCALE_HPP_

--- a/include/triggeralgs/dbscan/TriggerActivityMakerDBSCAN.hpp
+++ b/include/triggeralgs/dbscan/TriggerActivityMakerDBSCAN.hpp
@@ -25,7 +25,7 @@ public:
   void configure(const nlohmann::json &config);
   
 private:  
-  int m_min_pts; // Minimum number of points to form a cluster
+  int m_min_pts{3}; // Minimum number of points to form a cluster
   timestamp_t m_first_timestamp{0};
   timestamp_t m_prev_timestamp{0};
   std::vector<dbscan::Cluster> m_dbscan_clusters;

--- a/src/TriggerActivityMakerDBSCAN.cpp
+++ b/src/TriggerActivityMakerDBSCAN.cpp
@@ -1,0 +1,121 @@
+/**
+ * @file TriggerActivityMakerDBSCAN.cpp
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#include "triggeralgs/dbscan/TriggerActivityMakerDBSCAN.hpp"
+#include "dbscan/Point.hpp"
+
+#include "TRACE/trace.h"
+#include "triggeralgs/Types.hpp"
+#include <chrono>
+#include <limits>
+#define TRACE_NAME "TriggerActivityMakerDBSCAN"
+
+#include <vector>
+
+using namespace triggeralgs;
+
+void
+TriggerActivityMakerDBSCAN::operator()(const TriggerPrimitive& input_tp, std::vector<TriggerActivity>& output_ta)
+{
+  // Collection channels only for now
+  if(input_tp.channel%2560 < 1600){
+    return;
+  }
+  
+  if(input_tp.time_start < m_prev_timestamp){
+    TLOG(TLVL_INFO) << "Out-of-order TPs: prev " << m_prev_timestamp << ", current " << input_tp.time_start;
+    return;
+  }
+  
+  m_dbscan_clusters.clear();
+  m_dbscan->add_primitive(input_tp, &m_dbscan_clusters);
+
+  // if(!m_dbscan_clusters.empty()){
+  //   TLOG(TLVL_DEBUG) << "Got " << m_dbscan_clusters.size() << " clusters";
+  // }
+
+  uint64_t t0=m_dbscan->get_first_prim_time();
+  
+  // for(auto const& cluster : m_dbscan_clusters){
+  //   auto& ta=output_ta.emplace_back();
+
+  //   ta.time_start = std::numeric_limits<timestamp_t>::max();
+  //   ta.time_end = 0;
+  //   ta.channel_start = std::numeric_limits<channel_t>::max();
+  //   ta.channel_end = 0;
+  //   ta.adc_integral =  0;
+    
+  //   for(auto const& hit : cluster.hits){
+  //     timestamp_t hit_timestamp=t0+static_cast<timestamp_t>(hit->time);
+  //     ta.time_start = std::min(hit_timestamp, ta.time_start);
+  //     ta.time_end = std::max(hit_timestamp, ta.time_end);
+
+  //     ta.channel_start = std::min(hit->chan, ta.channel_start);
+  //     ta.channel_end = std::max(hit->chan, ta.channel_end);
+  //   }
+    
+  //   ta.time_peak = (ta.time_start+ta.time_end)/2;
+  //   ta.time_activity = ta.time_peak;
+
+  //   ta.channel_peak = (ta.channel_start+ta.channel_end)/2;
+
+  //   ta.type = TriggerActivity::Type::kTPC;
+  //   ta.algorithm = TriggerActivity::Algorithm::kDBSCAN;
+  //   ta.version = 1;
+
+  // }
+
+  for(auto const& cluster : m_dbscan_clusters){
+    auto& ta=output_ta.emplace_back();
+
+    ta.time_start = std::numeric_limits<timestamp_t>::max();
+    ta.time_end = 0;
+    ta.channel_start = std::numeric_limits<channel_t>::max();
+    ta.channel_end = 0;
+    ta.adc_integral =  0;
+    
+    for(auto const& hit : cluster.hits){
+      auto const& prim=hit->primitive;
+
+      ta.tp_list.push_back(prim);
+      
+      ta.time_start = std::min(prim.time_start, ta.time_start);
+      ta.time_end = std::max(prim.time_start + prim.time_over_threshold, ta.time_end);
+
+      ta.channel_start = std::min(prim.channel, ta.channel_start);
+      ta.channel_end = std::max(prim.channel, ta.channel_end);
+
+      ta.adc_integral += prim.adc_integral;
+
+      ta.detid = prim.detid;
+    }
+    
+    ta.time_peak = (ta.time_start+ta.time_end)/2;
+    ta.time_activity = ta.time_peak;
+
+    ta.channel_peak = (ta.channel_start+ta.channel_end)/2;
+
+    ta.type = TriggerActivity::Type::kTPC;
+    ta.algorithm = TriggerActivity::Algorithm::kDBSCAN;
+    ta.version = 1;
+
+  }
+
+  m_dbscan->trim_hits();
+}
+
+void
+TriggerActivityMakerDBSCAN::configure(const nlohmann::json &config)
+{
+  if (config.is_object() && config.contains("min_pts"))
+  {
+    m_min_pts = config["min_pts"];
+  }
+
+  m_dbscan=std::make_unique<dbscan::IncrementalDBSCAN>(10, m_min_pts);
+}

--- a/src/TriggerActivityMakerDBSCAN.cpp
+++ b/src/TriggerActivityMakerDBSCAN.cpp
@@ -84,5 +84,5 @@ TriggerActivityMakerDBSCAN::configure(const nlohmann::json &config)
     m_min_pts = config["min_pts"];
   }
 
-  m_dbscan=std::make_unique<dbscan::IncrementalDBSCAN>(10, m_min_pts);
+  m_dbscan=std::make_unique<dbscan::IncrementalDBSCAN>(10, m_min_pts, 10000);
 }

--- a/src/TriggerActivityMakerDBSCAN.cpp
+++ b/src/TriggerActivityMakerDBSCAN.cpp
@@ -82,7 +82,7 @@ TriggerActivityMakerDBSCAN::operator()(const TriggerPrimitive& input_tp, std::ve
     for(auto const& hit : cluster.hits){
       auto const& prim=hit->primitive;
 
-      ta.tp_list.push_back(prim);
+      ta.inputs.push_back(prim);
       
       ta.time_start = std::min(prim.time_start, ta.time_start);
       ta.time_end = std::max(prim.time_start + prim.time_over_threshold, ta.time_end);

--- a/src/TriggerActivityMakerDBSCAN.cpp
+++ b/src/TriggerActivityMakerDBSCAN.cpp
@@ -35,41 +35,8 @@ TriggerActivityMakerDBSCAN::operator()(const TriggerPrimitive& input_tp, std::ve
   m_dbscan_clusters.clear();
   m_dbscan->add_primitive(input_tp, &m_dbscan_clusters);
 
-  // if(!m_dbscan_clusters.empty()){
-  //   TLOG(TLVL_DEBUG) << "Got " << m_dbscan_clusters.size() << " clusters";
-  // }
-
   uint64_t t0=m_dbscan->get_first_prim_time();
   
-  // for(auto const& cluster : m_dbscan_clusters){
-  //   auto& ta=output_ta.emplace_back();
-
-  //   ta.time_start = std::numeric_limits<timestamp_t>::max();
-  //   ta.time_end = 0;
-  //   ta.channel_start = std::numeric_limits<channel_t>::max();
-  //   ta.channel_end = 0;
-  //   ta.adc_integral =  0;
-    
-  //   for(auto const& hit : cluster.hits){
-  //     timestamp_t hit_timestamp=t0+static_cast<timestamp_t>(hit->time);
-  //     ta.time_start = std::min(hit_timestamp, ta.time_start);
-  //     ta.time_end = std::max(hit_timestamp, ta.time_end);
-
-  //     ta.channel_start = std::min(hit->chan, ta.channel_start);
-  //     ta.channel_end = std::max(hit->chan, ta.channel_end);
-  //   }
-    
-  //   ta.time_peak = (ta.time_start+ta.time_end)/2;
-  //   ta.time_activity = ta.time_peak;
-
-  //   ta.channel_peak = (ta.channel_start+ta.channel_end)/2;
-
-  //   ta.type = TriggerActivity::Type::kTPC;
-  //   ta.algorithm = TriggerActivity::Algorithm::kDBSCAN;
-  //   ta.version = 1;
-
-  // }
-
   for(auto const& cluster : m_dbscan_clusters){
     auto& ta=output_ta.emplace_back();
 

--- a/src/dbscan/Hit.cpp
+++ b/src/dbscan/Hit.cpp
@@ -1,0 +1,81 @@
+#include "Hit.hpp"
+
+#include <algorithm>
+
+namespace dbscan {
+
+//======================================================================
+HitSet::HitSet()
+{
+    hits.reserve(10);
+}
+
+//======================================================================
+void
+HitSet::insert(Hit* h)
+{
+    // We're typically inserting hits at or near the end, so do a
+    // linear scan instead of full binary search. This turns out to be much
+    // faster in our case
+    auto it = hits.rbegin();
+    while (it != hits.rend() && (*it)->time >= h->time) {
+        // Don't insert the hit if we already have it
+        if (*it == h) {
+            return;
+        }
+        ++it;
+    }
+    
+    if (it == hits.rend() || *it != h) {
+        hits.insert(it.base(), h);
+    }
+}
+
+//======================================================================
+Hit::Hit(float _time, int _chan, const triggeralgs::TriggerPrimitive* _prim)
+{
+    reset(_time, _chan, _prim);
+}
+
+//======================================================================
+
+void
+Hit::reset(float _time, int _chan, const triggeralgs::TriggerPrimitive* _prim)
+{
+    time=_time;
+    chan=_chan;
+    cluster=kUndefined;
+    connectedness=Connectedness::kUndefined;
+    neighbours.clear();
+    if(_prim){
+        primitive=*_prim;
+    }
+}
+
+//======================================================================
+
+// Return true if hit was indeed a neighbour
+bool
+Hit::add_potential_neighbour(Hit* other, float eps, int minPts)
+{
+    if (other != this && euclidean_distance_sqr(*this, *other) < eps*eps) {
+        neighbours.insert(other);
+        if (neighbours.size() + 1 >= minPts) {
+            connectedness = Connectedness::kCore;
+        }
+        // Neighbourliness is symmetric
+        other->neighbours.insert(this);
+        if (other->neighbours.size() + 1 >= minPts) {
+            other->connectedness = Connectedness::kCore;
+        }
+        return true;
+    }
+    return false;
+}
+
+}
+// Local Variables:
+// mode: c++
+// c-basic-offset: 4
+// c-file-style: "linux"
+// End:

--- a/src/dbscan/Hit.hpp
+++ b/src/dbscan/Hit.hpp
@@ -1,0 +1,129 @@
+#pragma once
+
+#include "triggeralgs/TriggerActivity.hpp"
+#include "triggeralgs/TriggerPrimitive.hpp"
+#include <vector>
+#include <cmath>
+#include <list>
+
+namespace dbscan {
+//======================================================================
+
+// Special "cluster numbers" for hits that are not (yet) in a cluster
+const int kNoise = -2;
+const int kUndefined = -1;
+
+//======================================================================
+
+// Hit classifications in the DBSCAN scheme
+enum class Connectedness
+{
+    // clang-format off
+    kUndefined,
+    kNoise,     // Fewer than minPts neighbours, not in a cluster
+    kCore,      // minPts neighbours or more
+    kEdge       // Fewer than minPts neighbours, part of a cluster
+          // clang-format on
+};
+
+//======================================================================
+
+// As new hits arrive, they push forward the "current" time, and
+// eventually a given hit or cluster will know that it cannot be
+// modified any further. A hit becomes kComplete when its time is so
+// far behind the current time that new hits cannot be neighbours of
+// it. A cluster becomes kComplete when its latest hit is complete
+enum class Completeness
+{
+    kIncomplete,
+    kComplete,
+};
+
+class Hit;
+
+//======================================================================
+
+// An array of unique hits, sorted by time. The actual container
+// implementation is a std::vector, which seems to be faster than a
+// std::set (needs rechecking)
+class HitSet
+{
+public:
+    HitSet();
+
+    // Insert a hit in the set, if not already present. Keeps the
+    // array sorted by time
+    void insert(Hit* h);
+
+    std::vector<Hit*>::iterator begin() { return hits.begin(); }
+    std::vector<Hit*>::iterator end() { return hits.end(); }
+
+    std::vector<Hit*>::const_iterator begin() const { return hits.cbegin(); }
+    std::vector<Hit*>::const_iterator end() const { return hits.cend(); }
+
+    void clear() { hits.clear(); }
+
+    size_t size() const { return hits.size(); }
+
+    std::vector<Hit*> hits;
+};
+
+//======================================================================
+struct Hit
+{
+    Hit(float _time, int _chan, const triggeralgs::TriggerPrimitive* _prim=nullptr);
+
+    void reset(float _time, int _chan, const triggeralgs::TriggerPrimitive* _prim=nullptr);
+    // Add hit `other` to this hit's list of neighbours if they are
+    // closer than `eps`. Return true if so
+    bool add_potential_neighbour(Hit* other, float eps, int minPts);
+
+    float time;
+    int chan, cluster;
+    Connectedness connectedness;
+    HitSet neighbours;
+    triggeralgs::TriggerPrimitive primitive;
+};
+
+//======================================================================
+inline float
+manhattan_distance(const Hit& p, const Hit& q)
+{
+    return fabs((p.time - q.time)) + fabs(p.chan - q.chan);
+}
+
+//======================================================================
+template<class T>
+inline T
+sqr(T x)
+{
+    return x * x;
+}
+
+//======================================================================
+inline float
+euclidean_distance(const Hit& p, const Hit& q)
+{
+    return std::sqrt(sqr(p.time - q.time) + sqr(p.chan - q.chan));
+}
+
+//======================================================================
+inline float
+euclidean_distance_sqr(const Hit& p, const Hit& q)
+{
+    return sqr(p.time - q.time) + sqr(p.chan - q.chan);
+}
+
+//======================================================================
+inline bool
+time_comp_lower(const Hit* hit, const float t)
+{
+    return hit->time < t;
+}
+
+}
+// Local Variables:
+// mode: c++
+// c-basic-offset: 4
+// c-file-style: "linux"
+// End:

--- a/src/dbscan/Point.hpp
+++ b/src/dbscan/Point.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+namespace dbscan {
+
+struct Point
+{
+    int chan;
+    float time;
+};
+
+}

--- a/src/dbscan/dbscan.cpp
+++ b/src/dbscan/dbscan.cpp
@@ -1,0 +1,323 @@
+#include "dbscan.hpp"
+#include "Hit.hpp"
+
+#include <cassert>
+#include <limits>
+
+namespace dbscan {
+
+//======================================================================
+int
+neighbours_sorted(const std::vector<Hit*>& hits, Hit& q, float eps, int minPts)
+{
+    int n = 0;
+    // Loop over the hits starting from the latest hit, since we will
+    // ~always be adding a hit at recent times
+    for (auto hit_it = hits.rbegin(); hit_it != hits.rend(); ++hit_it) {
+        if ((*hit_it)->time > q.time + eps)
+            continue;
+        if ((*hit_it)->time < q.time - eps)
+            break;
+
+        if (q.add_potential_neighbour(*hit_it, eps, minPts))
+            ++n;
+    }
+    return n;
+}
+
+//======================================================================
+bool
+Cluster::maybe_add_new_hit(Hit* new_hit, float eps, int minPts)
+{
+    // Should we add this hit?
+    bool do_add = false;
+
+    // Hits earlier than new_hit time minus `eps` can't possibly be
+    // neighbours, so start the search there in the sorted list of hits in this
+    // cluster
+    auto begin_it = std::lower_bound(
+        hits.begin(), hits.end(), new_hit->time - eps, time_comp_lower);
+
+    for (auto it = begin_it; it != hits.end(); ++it) {
+        Hit* h = *it;
+        if (h->add_potential_neighbour(new_hit, eps, minPts)) {
+            do_add = true;
+            if (h->neighbours.size() + 1 >= minPts) {
+                h->connectedness = Connectedness::kCore;
+            } else {
+                h->connectedness = Connectedness::kEdge;
+            }
+        }
+    } // end loop over hits in cluster
+
+    if (do_add) {
+        add_hit(new_hit);
+    }
+
+    return do_add;
+}
+
+//======================================================================
+void
+Cluster::add_hit(Hit* h)
+{
+    hits.insert(h);
+    h->cluster = index;
+    latest_time = std::max(latest_time, h->time);
+    if (h->connectedness == Connectedness::kCore &&
+        (!latest_core_point || h->time > latest_core_point->time)) {
+        latest_core_point = h;
+    }
+}
+
+//======================================================================
+void
+Cluster::steal_hits(Cluster& other)
+{
+    // TODO: it might be faster to do some sort of explicit "merge" of the hits,
+    // eg:
+    //
+    // this->hits.insert(other hits); // Inserts at end
+    // std::inplace_merge(...)
+    //
+    // This might save some reallocations of the vector
+    for (auto h : other.hits) {
+        assert(h);
+        add_hit(h);
+    }
+    other.hits.clear();
+    other.completeness = Completeness::kComplete;
+}
+
+//======================================================================
+void
+IncrementalDBSCAN::cluster_reachable(Hit* seed_hit, Cluster& cluster)
+{
+    // Loop over all neighbours (and the neighbours of core points, and so on)
+    std::vector<Hit*> seedSet(seed_hit->neighbours.begin(),
+                              seed_hit->neighbours.end());
+
+    while (!seedSet.empty()) {
+        Hit* q = seedSet.back();
+        seedSet.pop_back();
+        // Change noise to a border point
+        if (q->connectedness == Connectedness::kNoise) {
+            cluster.add_hit(q);
+        }
+
+        if (q->cluster != kUndefined) {
+            continue;
+        }
+
+        cluster.add_hit(q);
+
+        // If q is a core point, add its neighbours to the search list
+        if (q->neighbours.size() + 1 >= m_minPts) {
+            q->connectedness = Connectedness::kCore;
+            seedSet.insert(
+                seedSet.end(), q->neighbours.begin(), q->neighbours.end());
+        }
+    }
+}
+
+//======================================================================
+void
+IncrementalDBSCAN::add_point(float time, float channel, std::vector<Cluster>* completed_clusters)
+{
+    Hit& new_hit=m_hit_pool[m_pool_end];
+    new_hit.reset(time, channel);
+    ++m_pool_end;
+    if(m_pool_end==m_hit_pool.size()) m_pool_end=0;
+    add_hit(&new_hit, completed_clusters);
+}
+
+//======================================================================
+void
+IncrementalDBSCAN::add_primitive(const triggeralgs::TriggerPrimitive& prim, std::vector<Cluster>* completed_clusters)
+{
+    if(m_first_prim_time==0){
+        m_first_prim_time=prim.time_start;
+    }
+    
+    Hit& new_hit=m_hit_pool[m_pool_end];
+    new_hit.reset(1e-2*(prim.time_start-m_first_prim_time), prim.channel, &prim);
+    ++m_pool_end;
+    if(m_pool_end==m_hit_pool.size()) m_pool_end=0;
+
+    add_hit(&new_hit, completed_clusters);
+}
+    
+//======================================================================
+void
+IncrementalDBSCAN::add_hit(Hit* new_hit, std::vector<Cluster>* completed_clusters)
+{
+    // TODO: this should be a member variable, not a static, in case
+    // there are multiple IncrementalDBSCAN instances
+    static int next_cluster_index = 0;
+
+    m_hits.push_back(new_hit);
+    m_latest_time = new_hit->time;
+
+    // All the clusters that this hit neighboured. If there are
+    // multiple clusters neighbouring this hit, we'll merge them at
+    // the end
+    std::set<int> clusters_neighbouring_hit;
+
+    // Find all the hit's neighbours
+    neighbours_sorted(m_hits, *new_hit, m_eps, m_minPts);
+
+    for (auto neighbour : new_hit->neighbours) {
+        if (neighbour->cluster != kUndefined && neighbour->cluster != kNoise &&
+            neighbour->neighbours.size() + 1 >= m_minPts) {
+            // This neighbour is a core point in a cluster. Add the cluster to the list of
+            // clusters that will contain this hit
+            clusters_neighbouring_hit.insert(neighbour->cluster);
+        }
+    }
+
+    if (clusters_neighbouring_hit.empty()) {
+        // This hit didn't match any existing cluster. See if we can
+        // make a new cluster out of it. Otherwise mark it as noise
+
+        if (new_hit->neighbours.size() + 1 >= m_minPts) {
+            // std::cout << "New cluster starting at hit time " << new_hit->time << " with " << new_hit->neighbours.size() << " neighbours" << std::endl;
+            new_hit->connectedness = Connectedness::kCore;
+            auto new_it = m_clusters.emplace_hint(
+                m_clusters.end(), next_cluster_index, next_cluster_index);
+            Cluster& new_cluster = new_it->second;
+            new_cluster.completeness = Completeness::kIncomplete;
+            new_cluster.add_hit(new_hit);
+            next_cluster_index++;
+            cluster_reachable(new_hit, new_cluster);
+        }
+        else{
+            // std::cout << "New hit time " << new_hit->time << " with " << new_hit->neighbours.size() << " neighbours is noise" << std::endl;
+        }
+    } else {
+        // This hit neighboured at least one cluster. Add the hit and
+        // its noise neighbours to the first cluster in the list, then
+        // merge the rest of the clusters into it
+
+        auto index_it = clusters_neighbouring_hit.begin();
+
+        auto it = m_clusters.find(*index_it);
+        assert(it != m_clusters.end());
+        Cluster& cluster = it->second;
+        // std::cout << "Adding hit time " << new_hit->time << " with " << new_hit->neighbours.size() << " neighbours to existing cluster" << std::endl;
+        cluster.add_hit(new_hit);
+
+        // TODO: this seems wrong: we're adding this hit's neighbours
+        // to the cluster even if this hit isn't a core point, but if
+        // I wrap the whole thing in "if(new_hit is core)" then the
+        // results differ from classic DBSCAN
+        for (auto q : new_hit->neighbours) {
+            if (q->cluster == kUndefined || q->cluster == kNoise) {
+                // std::cout << "  Adding hit time " << q->time << " to existing cluster" << std::endl;
+                cluster.add_hit(q);
+            }
+            // If the neighbouring hit q has exactly m_minPts
+            // neighbours, it must have become a core point by the
+            // addition of new_hit. Add q's neighbours to the cluster
+            if(q->neighbours.size() + 1 == m_minPts){
+                for (auto r : q->neighbours) {
+                    cluster.add_hit(r);
+                }
+            }
+        }
+
+
+        ++index_it;
+
+        for (; index_it != clusters_neighbouring_hit.end(); ++index_it) {
+
+            auto other_it = m_clusters.find(*index_it);
+            assert(other_it != m_clusters.end());
+            Cluster& other_cluster = other_it->second;
+            cluster.steal_hits(other_cluster);
+        }
+    }
+
+    // Last case: new_hit and its neighbour are both noise, but the
+    // addition of new_hit makes the neighbour a core point. So we
+    // start a new cluster at the neighbour, and walk out from there
+    for (auto& neighbour : new_hit->neighbours) {
+        if(neighbour->neighbours.size() + 1 >= m_minPts){
+            // std::cout << "new_hit's neighbour at " << neighbour->time << " has " << neighbour->neighbours.size() << " neighbours, so is core" << std::endl;
+            if(neighbour->cluster==kNoise || neighbour->cluster==kUndefined){
+                if(new_hit->cluster==kNoise || new_hit->cluster==kUndefined){
+                    auto new_it = m_clusters.emplace_hint(
+                                                          m_clusters.end(), next_cluster_index, next_cluster_index);
+                    Cluster& new_cluster = new_it->second;
+                    new_cluster.completeness = Completeness::kIncomplete;
+                    new_cluster.add_hit(neighbour);
+                    next_cluster_index++;
+                    cluster_reachable(neighbour, new_cluster);
+                }
+            }
+        }
+        else {
+            // std::cout << "new_hit's neighbour at " << neighbour->time << " has " << neighbour->neighbours.size() << " neighbours, so is NOT core" << std::endl;
+        }
+    }
+
+
+    // Delete any completed clusters from the list. Put them in the
+    // `completed_clusters` vector, if that vector was passed
+    auto clust_it = m_clusters.begin();
+    while (clust_it != m_clusters.end()) {
+        Cluster& cluster = clust_it->second;
+
+        if (cluster.latest_time < m_latest_time - m_eps) {
+            cluster.completeness = Completeness::kComplete;
+        }
+
+        if (cluster.completeness == Completeness::kComplete) {
+            if(completed_clusters){
+                // TODO: room for std::move here?
+                //
+                // Clusters that got merged into another cluster had
+                // their hits cleared, and were set kComplete, by
+                // steal_hits
+                if(cluster.hits.size()!=0){
+                    completed_clusters->push_back(cluster);
+                }
+            }
+            clust_it = m_clusters.erase(clust_it);
+            continue;
+        } else {
+            ++clust_it;
+        }
+    }
+}
+
+void
+IncrementalDBSCAN::trim_hits()
+{
+    // Find the earliest time of a hit in any cluster in the list (active or
+    // not)
+    float earliest_time = std::numeric_limits<float>::max();
+
+    for (auto& cluster : m_clusters) {
+        earliest_time =
+            std::min(earliest_time, (*cluster.second.hits.begin())->time);
+    }
+
+    // If there were no clusters, set the earliest_time to the latest time
+    // (otherwise it would still be FLOAT_MAX)
+    if (m_clusters.empty()) {
+        earliest_time = m_latest_time;
+    }
+    auto last_it = std::lower_bound(m_hits.begin(),
+                                    m_hits.end(),
+                                    earliest_time - 10 * m_eps,
+                                    time_comp_lower);
+
+    m_hits.erase(m_hits.begin(), last_it);
+}
+
+}
+// Local Variables:
+// mode: c++
+// c-basic-offset: 4
+// c-file-style: "linux"
+// End:

--- a/src/dbscan/dbscan.hpp
+++ b/src/dbscan/dbscan.hpp
@@ -1,0 +1,110 @@
+#pragma once
+
+#include <vector>
+#include <map>
+#include <iostream>
+#include <algorithm> // For std::lower_bound
+#include <set>
+#include <list>
+
+#include "Hit.hpp"
+#include "triggeralgs/TriggerPrimitive.hpp"
+
+namespace dbscan {
+//======================================================================
+// Find the eps-neighbours of hit q, assuming that the hits vector is sorted by
+// time
+int
+neighbours_sorted(const std::vector<Hit*>& hits, Hit& q, float eps, int minPts);
+
+//======================================================================
+struct Cluster
+{
+    Cluster(int index_)
+        : index{ index_ }
+    {}
+    // The index of this cluster
+    int index{ -1 };
+    // A cluster is kComplete if its hits are all kComplete, so no
+    // newly-arriving hit could be a neighbour of any hit in the
+    // cluster
+    Completeness completeness{ Completeness::kIncomplete };
+    // The latest time of any hit in the cluster
+    float latest_time{ 0 };
+    // The latest (largest time) "core" point in the cluster
+    Hit* latest_core_point{ nullptr };
+    // The hits in this cluster
+    HitSet hits;
+
+    // Add hit if it's a neighbour of a hit already in the
+    // cluster. Precondition: time of new_hit is >= the time of any
+    // hit in the cluster. Returns true if the hit was added
+    bool maybe_add_new_hit(Hit* new_hit, float eps, int minPts);
+
+    // Add the hit `h` to this cluster
+    void add_hit(Hit* h);
+
+    // Steal all of the hits from cluster `other` and merge them into
+    // this cluster
+    void steal_hits(Cluster& other);
+};
+
+//======================================================================
+//
+// Modified DBSCAN algorithm that takes one hit at a time, with the requirement
+// that the hits are passed in time order
+class IncrementalDBSCAN
+{
+public:
+    IncrementalDBSCAN(float eps, unsigned int minPts, size_t pool_size=100000)
+        : m_eps(eps)
+        , m_minPts(minPts)
+        , m_pool_begin(0)
+        , m_pool_end(0)
+    {
+        for(size_t i=0; i<pool_size; ++i){
+            m_hit_pool.emplace_back(0,0);
+        }
+    }
+
+    void add_primitive(const triggeralgs::TriggerPrimitive& prim, std::vector<Cluster>* completed_clusters=nullptr);
+    
+    void add_point(float time, float channel, std::vector<Cluster>* completed_clusters=nullptr);
+    
+    // Add a new hit. The hit time *must* be >= the time of all hits
+    // previously added
+    void add_hit(Hit* new_hit, std::vector<Cluster>* completed_clusters=nullptr);
+
+    void trim_hits();
+
+    std::vector<Hit*> get_hits() const { return m_hits; }
+
+    std::map<int, Cluster> get_clusters() const { return m_clusters; }
+
+    uint64_t get_first_prim_time() const { return m_first_prim_time; }
+    
+private:
+    //======================================================================
+    //
+    // Starting from `seed_hit`, find all the reachable hits and add them
+    // to `cluster`
+    void cluster_reachable(Hit* seed_hit, Cluster& cluster);
+
+    float m_eps;
+    float m_minPts;
+    std::vector<Hit> m_hit_pool;
+    size_t m_pool_begin, m_pool_end;
+    std::vector<Hit*> m_hits; // All the hits we've seen so far, in time order
+    float m_latest_time{ 0 }; // The latest time of a hit in the vector of hits
+    uint64_t m_first_prim_time{0};
+    std::map<int, Cluster>
+        m_clusters; // All of the currently-active (ie, kIncomplete) clusters
+};
+
+}
+
+// Local Variables:
+// mode: c++
+// c-basic-offset: 4
+// c-file-style: "linux"
+// End:


### PR DESCRIPTION
This PR adds a DBSCAN-based trigger activity maker. Some details of how it works can be found in https://indico.fnal.gov/event/56134/contributions/250045/attachments/159452/209627/dbscan-clustering-2022-09-06.pdf

This PR needs https://github.com/DUNE-DAQ/detdataformats/pull/42 to be merged first