### PR TITLE
Re-arranged the location of dbscan header files to avoid build problems…

### DIFF
--- a/include/triggeralgs/dbscan/Hit.hpp
+++ b/include/triggeralgs/dbscan/Hit.hpp
@@ -6,6 +6,7 @@
 #include <cmath>
 #include <list>
 
+namespace triggeralgs {
 namespace dbscan {
 //======================================================================
 
@@ -121,6 +122,7 @@ time_comp_lower(const Hit* hit, const float t)
     return hit->time < t;
 }
 
+}
 }
 // Local Variables:
 // mode: c++

--- a/include/triggeralgs/dbscan/TriggerActivityMakerDBSCAN.hpp
+++ b/include/triggeralgs/dbscan/TriggerActivityMakerDBSCAN.hpp
@@ -10,7 +10,7 @@
 #define TRIGGERALGS_DBSCAN_TRIGGERACTIVITYMAKERDBSCAN_HPP_
 
 #include "triggeralgs/TriggerActivityMaker.hpp"
-#include "dbscan/dbscan.hpp"
+#include "triggeralgs/dbscan/dbscan.hpp"
 
 #include <memory>
 #include <vector>

--- a/include/triggeralgs/dbscan/dbscan.hpp
+++ b/include/triggeralgs/dbscan/dbscan.hpp
@@ -7,9 +7,10 @@
 #include <set>
 #include <list>
 
-#include "Hit.hpp"
+#include "triggeralgs/dbscan/Hit.hpp"
 #include "triggeralgs/TriggerPrimitive.hpp"
 
+namespace triggeralgs {
 namespace dbscan {
 //======================================================================
 // Find the eps-neighbours of hit q, assuming that the hits vector is sorted by
@@ -101,6 +102,7 @@ private:
         m_clusters; // All of the currently-active (ie, kIncomplete) clusters
 };
 
+}
 }
 
 // Local Variables:

--- a/src/dbscan/Hit.cpp
+++ b/src/dbscan/Hit.cpp
@@ -1,7 +1,8 @@
-#include "Hit.hpp"
+#include "triggeralgs/dbscan/Hit.hpp"
 
 #include <algorithm>
 
+namespace triggeralgs {
 namespace dbscan {
 
 //======================================================================
@@ -73,6 +74,7 @@ Hit::add_potential_neighbour(Hit* other, float eps, int minPts)
     return false;
 }
 
+}
 }
 // Local Variables:
 // mode: c++

--- a/src/dbscan/dbscan.cpp
+++ b/src/dbscan/dbscan.cpp
@@ -1,9 +1,10 @@
-#include "dbscan.hpp"
-#include "Hit.hpp"
+#include "triggeralgs/dbscan/dbscan.hpp"
+#include "triggeralgs/dbscan/Hit.hpp"
 
 #include <cassert>
 #include <limits>
 
+namespace triggeralgs {
 namespace dbscan {
 
 //======================================================================
@@ -315,6 +316,7 @@ IncrementalDBSCAN::trim_hits()
     m_hits.erase(m_hits.begin(), last_it);
 }
 
+}
 }
 // Local Variables:
 // mode: c++


### PR DESCRIPTION
…when using pre-built packages.

This change does not have anything to do with the v3.2.0 release.  Its goal is to get the nightly build based on `develop` branches working again.

I have verified that these changes still compile correctly in a software development environment that has both `trigger` and `triggeralgs` included.  I will talk with Pengfei about how to test with a pre-built version of `triggeralgs`.

I have **not** done any functional testing of these these changes.