### PR TITLE
Adding in potentially useful logging information for FW and SW TPG runs.

### DIFF
--- a/include/triggeralgs/HorizontalMuon/TriggerActivityMakerHorizontalMuon.hpp
+++ b/include/triggeralgs/HorizontalMuon/TriggerActivityMakerHorizontalMuon.hpp
@@ -113,6 +113,7 @@ private:
   bool m_trigger_on_adc = false;
   bool m_trigger_on_n_channels = false;
   bool m_trigger_on_adjacency = true;    // Default use of the horizontal muon triggering
+  bool m_print_tp_info = false;          // Prints out some information on every TP received
   uint16_t m_adjacency_threshold = 15;   // Default is 15 wire track for testing
   int m_max_adjacency = 0;               // The maximum adjacency seen so far in any window
   uint32_t m_adc_threshold = 3000000;    // Not currently triggering on this

--- a/include/triggeralgs/HorizontalMuon/TriggerActivityMakerHorizontalMuon.hpp
+++ b/include/triggeralgs/HorizontalMuon/TriggerActivityMakerHorizontalMuon.hpp
@@ -123,6 +123,8 @@ private:
   uint16_t ta_adc = 0;
   uint16_t ta_channels = 0;
   timestamp_t m_window_length = 8000;    // Shouldn't exceed the max drift
+  uint16_t ta_count = 0;                  // Use for prescaling
+  uint16_t m_prescale = 1;                // Prescale value, defult is one, trigger every TA
 
   // For debugging purposes.
   void add_window_to_record(Window window);

--- a/src/TriggerActivityMakerHorizontalMuon.cpp
+++ b/src/TriggerActivityMakerHorizontalMuon.cpp
@@ -17,6 +17,14 @@ void
 TriggerActivityMakerHorizontalMuon::operator()(const TriggerPrimitive& input_tp,
                                                std::vector<TriggerActivity>& output_ta)
 {
+  // Add useful info about recived TPs here for FW and SW TPG guys.
+  if (m_print_tp_info){
+    TLOG(1) << "TP Start Time: " << input_tp.time_start << ", TP ADC Sum: " <<  input_tp.adc_integral
+	    << ", TP TOT: " << input_tp.time_over_threshold << ", TP ADC Peak: " << input_tp.adc_peak
+     	    << ", TP Offline Channel ID: " << input_tp.channel;    
+  }
+
+
   // 0) FIRST TP =====================================================================
   // The first time operator() is called, reset the window object.
   if (m_current_window.is_empty()) {
@@ -37,6 +45,10 @@ TriggerActivityMakerHorizontalMuon::operator()(const TriggerPrimitive& input_tp,
   // window is above the configured threshold. If it is, and we are triggering on ADC,
   // make a TA and start a fresh window with the current TP.
   else if (m_current_window.adc_integral > m_adc_threshold && m_trigger_on_adc) {
+
+    TLOG(1) << "Emitting ADC threshold trigger with " << m_current_window.adc_integral <<
+               " window ADC integral.";
+
     output_ta.push_back(construct_ta());
     m_current_window.reset(input_tp);
   }
@@ -101,6 +113,8 @@ TriggerActivityMakerHorizontalMuon::configure(const nlohmann::json& config)
       m_adj_tolerance = config["adj_tolerance"];
     if (config.contains("adjacency_threshold"))
       m_adjacency_threshold = config["adjacency_threshold"];
+    if (config.contains("print_tp_info"))
+      m_print_tp_info = config["print_tp_info"];
   }
 
 }

--- a/src/TriggerActivityMakerHorizontalMuon.cpp
+++ b/src/TriggerActivityMakerHorizontalMuon.cpp
@@ -46,11 +46,15 @@ TriggerActivityMakerHorizontalMuon::operator()(const TriggerPrimitive& input_tp,
   // make a TA and start a fresh window with the current TP.
   else if (m_current_window.adc_integral > m_adc_threshold && m_trigger_on_adc) {
 
-    TLOG(1) << "Emitting ADC threshold trigger with " << m_current_window.adc_integral <<
-               " window ADC integral.";
+    ta_count++;
+    if (ta_count % m_prescale == 0){
 
-    output_ta.push_back(construct_ta());
-    m_current_window.reset(input_tp);
+    	TLOG(1) << "Emitting ADC threshold trigger with " << m_current_window.adc_integral <<
+                   " window ADC integral.";
+
+    	output_ta.push_back(construct_ta());
+    	m_current_window.reset(input_tp);
+    }
   }
 
   // 2) MULTIPLICITY - N UNQIUE CHANNELS EXCEEDED =====================================
@@ -60,11 +64,15 @@ TriggerActivityMakerHorizontalMuon::operator()(const TriggerPrimitive& input_tp,
   // on channel multiplicity, make a TA and start a fresh window with the current TP.
   else if (m_current_window.n_channels_hit() > m_n_channels_threshold && m_trigger_on_n_channels) {
 
-    TLOG(1) << "Emitting multiplicity trigger with " << m_current_window.n_channels_hit() <<
-               " unique channels hit.";
+    ta_count++;
+    if (ta_count % m_prescale == 0){
 
-    output_ta.push_back(construct_ta());
-    m_current_window.reset(input_tp);
+    	TLOG(1) << "Emitting multiplicity trigger with " << m_current_window.n_channels_hit() <<
+                   " unique channels hit.";
+
+    	output_ta.push_back(construct_ta());
+    	m_current_window.reset(input_tp);
+    }
   }
 
   // 3) ADJACENCY THRESHOLD EXCEEDED ==================================================
@@ -74,14 +82,18 @@ TriggerActivityMakerHorizontalMuon::operator()(const TriggerPrimitive& input_tp,
   // on adjacency, then create a TA and reset the window with the new/current TP.
   else if (check_adjacency() > m_adjacency_threshold &&  m_trigger_on_adjacency) {
 
-    // Check for a new maximum, display the largest seen adjacency in the log.
-    uint16_t adjacency = check_adjacency();
-    if (adjacency > m_max_adjacency) { m_max_adjacency = adjacency; }
-    TLOG(1) << "Emitting adjacency TA with adjacency " << check_adjacency() <<
-               " and the largest seen so far is " << m_max_adjacency;
+    ta_count++;
+    if (ta_count % m_prescale == 0){   
 
-    output_ta.push_back(construct_ta());
-    m_current_window.reset(input_tp);
+    	// Check for a new maximum, display the largest seen adjacency in the log.
+    	uint16_t adjacency = check_adjacency();
+    	if (adjacency > m_max_adjacency) { m_max_adjacency = adjacency; }
+    		TLOG(1) << "Emitting adjacency TA with adjacency " << check_adjacency() <<
+               		   " and the largest seen so far is " << m_max_adjacency;
+
+   	 	output_ta.push_back(construct_ta());
+    		m_current_window.reset(input_tp);
+     }
   }
 
   // 4) Otherwise, slide the window along using the current TP.
@@ -115,7 +127,9 @@ TriggerActivityMakerHorizontalMuon::configure(const nlohmann::json& config)
       m_adjacency_threshold = config["adjacency_threshold"];
     if (config.contains("print_tp_info"))
       m_print_tp_info = config["print_tp_info"];
-  }
+    if (config.contains("prescale"))
+      m_prescale = config["prescale"]; 
+ }
 
 }
 


### PR DESCRIPTION
I've added in some logs, and a flag to indicate whether or not to print out incoming TP information. The TPs seen at the TAMaker for the HorizontalMuon algorithm will display some information if the configurable parameter for it `print_tp_info` is set to `true`. The default is `false` however, since it increases the log file sizes significantly. 

I added this in anticipating a useful debugging tool for FW and SW TPG tests that might be done during the November cold box runs.