### PR TITLE
Restore TCMakerPrescale Window Mechanism

### DIFF
--- a/include/triggeralgs/Prescale/TriggerCandidateMakerPrescale.hpp
+++ b/include/triggeralgs/Prescale/TriggerCandidateMakerPrescale.hpp
@@ -27,8 +27,8 @@ private:
 
   uint64_t m_activity_count = 0;    // NOLINT(build/unsigned)
   uint64_t m_prescale = 1;          // NOLINT(build/unsigned)
-  timestamp_t m_readout_window_ticks_before = 32768; 
-  timestamp_t m_readout_window_ticks_after = 32768;
+  timestamp_t m_readout_window_ticks_before = 0; 
+  timestamp_t m_readout_window_ticks_after = 0;
   
 };
 

--- a/src/TriggerCandidateMakerPrescale.cpp
+++ b/src/TriggerCandidateMakerPrescale.cpp
@@ -27,7 +27,7 @@ TriggerCandidateMakerPrescale::operator()(const TriggerActivity& activity, std::
     
     TriggerCandidate tc;
     tc.time_start = activity.time_start - m_readout_window_ticks_before;
-    tc.time_end = activity.time_start + m_readout_window_ticks_after;
+    tc.time_end = activity.time_end + m_readout_window_ticks_after;
     tc.time_candidate = activity.time_start;
     tc.detid = activity.detid;
     tc.type = TriggerCandidate::Type::kPrescale;


### PR DESCRIPTION
Fixes the issues we were seeing with the `3ru_3df_multirun_test.py` integrations test.

The issue is that we had adjusted the way in which the readout was constructed for the recent VDCB runs at EHN1, and for every trigger (corresponding to a single TP - typically of length O(10s) of ticks) - we were requesting readout windows on the order 70k ticks in the test. Doing this for every triggered TP in this test obviously caused problems, and DFO could not keep up, inhibiting triggers, hence the log warnings.

The current state of this branch restores the Prescale window setting mechanism to it's former glory, and allows the above integration test to run to completion, without error.