### PR TITLE
FD/ND split of detdataformats

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ set(CMAKE_INSTALL_CMAKEDIR   ${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}/cmake )
 find_package(nlohmann_json REQUIRED)
 find_package(TRACE REQUIRED)
 find_package(detdataformats REQUIRED)
+find_package(trgdataformats REQUIRED)
 find_package(cetlib REQUIRED)
 find_package(detchannelmaps REQUIRED)
 
@@ -56,7 +57,7 @@ target_include_directories(triggeralgs PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
   )
-target_link_libraries(triggeralgs PRIVATE nlohmann_json::nlohmann_json detdataformats::detdataformats cetlib::cetlib detchannelmaps::detchannelmaps)
+target_link_libraries(triggeralgs PRIVATE nlohmann_json::nlohmann_json detdataformats::detdataformats trgdataformats::trgdataformats cetlib::cetlib detchannelmaps::detchannelmaps)
 install(TARGETS triggeralgs EXPORT triggeralgsTargets)
 
 CONFIGURE_PACKAGE_CONFIG_FILE(cmake/triggeralgsConfig.cmake.in

--- a/cmake/triggeralgsConfig.cmake.in
+++ b/cmake/triggeralgsConfig.cmake.in
@@ -10,6 +10,7 @@ include(CMakeFindDependencyMacro)
 find_dependency(nlohmann_json)
 find_dependency(TRACE)
 find_dependency(detdataformats)
+find_dependency(trgdataformats)
 find_dependency(cetlib)
 find_dependency(detchannelmaps)
 

--- a/include/triggeralgs/Supernova/TriggerCandidateMakerSupernova.hpp
+++ b/include/triggeralgs/Supernova/TriggerCandidateMakerSupernova.hpp
@@ -41,7 +41,7 @@ protected:
   {
     timestamp_diff_t how_far = time_now - m_time_window;
     auto end = std::remove_if(
-                              m_activity.begin(), m_activity.end(), [how_far, this](auto& c) -> bool { return (static_cast<dunedaq::detdataformats::trigger::timestamp_diff_t>(c.time_start) < how_far); });
+                              m_activity.begin(), m_activity.end(), [how_far, this](auto& c) -> bool { return (static_cast<dunedaq::trgdataformats::timestamp_diff_t>(c.time_start) < how_far); });
     m_activity.erase(end, m_activity.end());
   }
 };

--- a/include/triggeralgs/Supernova/TriggerDecisionMakerSupernova.hpp
+++ b/include/triggeralgs/Supernova/TriggerDecisionMakerSupernova.hpp
@@ -10,7 +10,7 @@
 #define TRIGGERALGS_SRC_TRIGGERALGS_SUPERNOVA_TRIGGERDECISIONMAKERSUPERNOVA_HPP_
 
 #include "triggeralgs/TriggerDecisionMaker.hpp"
-#include "detdataformats/trigger/Types.hpp"
+#include "trgdataformats/Types.hpp"
 
 #include <algorithm>
 #include <atomic>
@@ -29,18 +29,18 @@ public:
 protected:
   std::vector<TriggerCandidate> m_candidate;
   /// Sliding time window to count activities
-  std::atomic<dunedaq::detdataformats::trigger::timestamp_t> m_time_window = { 500'000'000 };
+  std::atomic<dunedaq::trgdataformats::timestamp_t> m_time_window = { 500'000'000 };
   /// Minimum number of activities in the time window to issue a trigger
   std::atomic<uint16_t> m_threshold = { 1 }; // NOLINT(build/unsigned)
   /// Minimum number of primities in an activity
   std::atomic<uint16_t> m_hit_threshold = { 1 }; // NOLINT(build/unsigned)
 
   /// this function gets rid of the old activities
-  void FlushOldCandidate(dunedaq::detdataformats::trigger::timestamp_t time_now)
+  void FlushOldCandidate(dunedaq::trgdataformats::timestamp_t time_now)
   {
-    dunedaq::detdataformats::trigger::timestamp_diff_t how_far = time_now - m_time_window;
+    dunedaq::trgdataformats::timestamp_diff_t how_far = time_now - m_time_window;
     auto end = std::remove_if(
-                              m_candidate.begin(), m_candidate.end(), [how_far, this](auto& c) -> bool { return (static_cast<dunedaq::detdataformats::trigger::timestamp_diff_t>(c.time_start) < how_far); });
+                              m_candidate.begin(), m_candidate.end(), [how_far, this](auto& c) -> bool { return (static_cast<dunedaq::trgdataformats::timestamp_diff_t>(c.time_start) < how_far); });
     m_candidate.erase(end, m_candidate.end());
   }
 };

--- a/include/triggeralgs/TriggerActivity.hpp
+++ b/include/triggeralgs/TriggerActivity.hpp
@@ -9,14 +9,14 @@
 #ifndef TRIGGERALGS_INCLUDE_TRIGGERALGS_TRIGGERACTIVITY_HPP_
 #define TRIGGERALGS_INCLUDE_TRIGGERALGS_TRIGGERACTIVITY_HPP_
 
-#include "detdataformats/trigger/TriggerActivityData.hpp"
+#include "trgdataformats/TriggerActivityData.hpp"
 #include "triggeralgs/TriggerPrimitive.hpp"
 
 #include <vector>
 
 namespace triggeralgs {
 
-struct TriggerActivity : public dunedaq::detdataformats::trigger::TriggerActivityData
+struct TriggerActivity : public dunedaq::trgdataformats::TriggerActivityData
 {
   std::vector<TriggerPrimitive> inputs;
 };

--- a/include/triggeralgs/TriggerCandidate.hpp
+++ b/include/triggeralgs/TriggerCandidate.hpp
@@ -9,16 +9,16 @@
 #ifndef TRIGGERALGS_INCLUDE_TRIGGERALGS_TRIGGERCANDIDATE_HPP_
 #define TRIGGERALGS_INCLUDE_TRIGGERALGS_TRIGGERCANDIDATE_HPP_
 
-#include "detdataformats/trigger/TriggerActivityData.hpp"
-#include "detdataformats/trigger/TriggerCandidateData.hpp"
+#include "trgdataformats/TriggerActivityData.hpp"
+#include "trgdataformats/TriggerCandidateData.hpp"
 
 #include <vector>
 
 namespace triggeralgs {
 
-struct TriggerCandidate : public dunedaq::detdataformats::trigger::TriggerCandidateData
+struct TriggerCandidate : public dunedaq::trgdataformats::TriggerCandidateData
 {
-  std::vector<dunedaq::detdataformats::trigger::TriggerActivityData> inputs;
+  std::vector<dunedaq::trgdataformats::TriggerActivityData> inputs;
 };
 
 } // namespace triggeralgs

--- a/include/triggeralgs/TriggerObjectOverlay.hpp
+++ b/include/triggeralgs/TriggerObjectOverlay.hpp
@@ -10,8 +10,8 @@
 #define TRIGGERALGS_INCLUDE_TRIGGERALGS_TRIGGEROBJECTOVERLAY_HPP_
 
 
-#include "detdataformats/trigger/TriggerActivityData.hpp"
-#include "detdataformats/trigger/TriggerObjectOverlay.hpp"
+#include "trgdataformats/TriggerActivityData.hpp"
+#include "trgdataformats/TriggerObjectOverlay.hpp"
 
 #include "triggeralgs/TriggerPrimitive.hpp"
 #include "triggeralgs/TriggerActivity.hpp"
@@ -20,12 +20,12 @@
 namespace triggeralgs {
 
 // TypeToOverlayType acts as a "map" from a type to its overlay type
-// (eg from TriggerCandidate to dunedaq::detdataformats::trigger::TriggerCandidate). The point of
+// (eg from TriggerCandidate to dunedaq::trgdataformats::TriggerCandidate). The point of
 // having this is so that we can call the various overlay conversion
 // functions below without having to explicitly specify the template
 // arguments. An alternative way to do this would be to have
 // TriggerActivity and TriggerCandidate each contain a using declaration
-// like `using overlay_t = dunedaq::detdataformats::trigger::Trigger(Activity|Candidate);`, but I
+// like `using overlay_t = dunedaq::trgdataformats::Trigger(Activity|Candidate);`, but I
 // couldn't figure out the right forward declaration for the overlay
 // types in the TriggerCandidate/TriggerActivity header files
 template<class T>
@@ -34,15 +34,15 @@ struct TypeToOverlayType;
 template<>
 struct TypeToOverlayType<TriggerActivity>
 {
-  using overlay_t = dunedaq::detdataformats::trigger::TriggerActivity;
-  using data_t = dunedaq::detdataformats::trigger::TriggerActivityData;
+  using overlay_t = dunedaq::trgdataformats::TriggerActivity;
+  using data_t = dunedaq::trgdataformats::TriggerActivityData;
 };
 
 template<>
 struct TypeToOverlayType<TriggerCandidate>
 {
-  using overlay_t = dunedaq::detdataformats::trigger::TriggerCandidate;
-  using data_t = dunedaq::detdataformats::trigger::TriggerCandidateData;
+  using overlay_t = dunedaq::trgdataformats::TriggerCandidate;
+  using data_t = dunedaq::trgdataformats::TriggerCandidateData;
 };
 
 // Populate a TriggerObjectOverlay in `buffer`, created from
@@ -73,8 +73,8 @@ get_overlay_nbytes(const Object& object)
   return sizeof(Overlay) + object.inputs.size() * sizeof(typename Overlay::input_t);
 }
 
-// Given an overlay object (dunedaq::detdataformats::trigger::TriggerActivity or
-// dunedaq::detdataformats::trigger::TriggerCandidate), create a corresponding non-overlay object
+// Given an overlay object (dunedaq::trgdataformats::TriggerActivity or
+// dunedaq::trgdataformats::TriggerCandidate), create a corresponding non-overlay object
 // (triggeralgs::TriggerActivity or triggeralgs::TriggerCandidate) with the same contents, and return it
 template<class Object, class Overlay = typename TypeToOverlayType<Object>::overlay_t,
          class Data = typename TypeToOverlayType<Object>::data_t>
@@ -95,8 +95,8 @@ read_overlay(const Overlay& overlay)
   return ret;
 }
 
-// Given a buffer containing an overlay object (dunedaq::detdataformats::trigger::TriggerActivity
-// or dunedaq::detdataformats::trigger::TriggerCandidate), create a corresponding non-overlay
+// Given a buffer containing an overlay object (dunedaq::trgdataformats::TriggerActivity
+// or dunedaq::trgdataformats::TriggerCandidate), create a corresponding non-overlay
 // object (triggeralgs::TriggerActivity or triggeralgs::TriggerCandidate) with the same
 // contents, and return it. This function requires the return type to
 // be explicitly specified as a template argument, unlike the other

--- a/include/triggeralgs/TriggerPrimitive.hpp
+++ b/include/triggeralgs/TriggerPrimitive.hpp
@@ -9,7 +9,7 @@
 #ifndef TRIGGERALGS_INCLUDE_TRIGGERALGS_TRIGGERPRIMITIVE_HPP_
 #define TRIGGERALGS_INCLUDE_TRIGGERALGS_TRIGGERPRIMITIVE_HPP_
 
-#include "detdataformats/trigger/TriggerPrimitive.hpp"
+#include "trgdataformats/TriggerPrimitive.hpp"
 
 namespace triggeralgs {
 // TriggerPrimitive looks a bit difference to TriggerActivity and
@@ -19,7 +19,7 @@ namespace triggeralgs {
 // definition only in detdataformats. So we just copy it here so that
 // references to TP, TA and TC in triggeralgs and downstream code
 // "look" the same
-using TriggerPrimitive = dunedaq::detdataformats::trigger::TriggerPrimitive;
+using TriggerPrimitive = dunedaq::trgdataformats::TriggerPrimitive;
 
 } // namespace triggeralgs
 

--- a/include/triggeralgs/TriggerPrimitiveMaker.hpp
+++ b/include/triggeralgs/TriggerPrimitiveMaker.hpp
@@ -9,7 +9,7 @@
 #ifndef TRIGGERALGS_INCLUDE_TRIGGERALGS_TRIGGERPRIMITIVEMAKER_HPP_
 #define TRIGGERALGS_INCLUDE_TRIGGERALGS_TRIGGERPRIMITIVEMAKER_HPP_
 
-#include "detdataformats/trigger/TriggerPrimitive.hpp"
+#include "trgdataformats/TriggerPrimitive.hpp"
 
 #include <nlohmann/json.hpp>
 #include <vector>
@@ -20,8 +20,8 @@ class TriggerPrimitiveMaker
 {
 public:
   virtual ~TriggerPrimitiveMaker() = default;
-  virtual void operator()(const void* input_rawdata, std::vector<dunedaq::detdataformats::trigger::TriggerPrimitive>& output_tp) = 0;
-  virtual void flush(std::vector<dunedaq::detdataformats::trigger::TriggerPrimitive>&) {}
+  virtual void operator()(const void* input_rawdata, std::vector<dunedaq::trgdataformats::TriggerPrimitive>& output_tp) = 0;
+  virtual void flush(std::vector<dunedaq::trgdataformats::TriggerPrimitive>&) {}
   virtual void configure(const nlohmann::json&) {}
 };
 

--- a/include/triggeralgs/Types.hpp
+++ b/include/triggeralgs/Types.hpp
@@ -9,16 +9,16 @@
 #ifndef TRIGGERALGS_INCLUDE_TRIGGERALGS_TYPES_HPP_
 #define TRIGGERALGS_INCLUDE_TRIGGERALGS_TYPES_HPP_
 
-#include "detdataformats/trigger/Types.hpp"
+#include "trgdataformats/Types.hpp"
 
 namespace triggeralgs {
 
-using timestamp_t = dunedaq::detdataformats::trigger::timestamp_t;
-using timestamp_diff_t = dunedaq::detdataformats::trigger::timestamp_diff_t;
-using detid_t = dunedaq::detdataformats::trigger::detid_t;
-using trigger_number_t = dunedaq::detdataformats::trigger::trigger_number_t;
-using channel_t = dunedaq::detdataformats::trigger::channel_t;
-using version_t = dunedaq::detdataformats::trigger::version_t;
+using timestamp_t = dunedaq::trgdataformats::timestamp_t;
+using timestamp_diff_t = dunedaq::trgdataformats::timestamp_diff_t;
+using detid_t = dunedaq::trgdataformats::detid_t;
+using trigger_number_t = dunedaq::trgdataformats::trigger_number_t;
+using channel_t = dunedaq::trgdataformats::channel_t;
+using version_t = dunedaq::trgdataformats::version_t;
 
 } // namespace triggeralgs
 

--- a/src/TriggerCandidateMakerSupernova.cpp
+++ b/src/TriggerCandidateMakerSupernova.cpp
@@ -21,7 +21,7 @@ TriggerCandidateMakerSupernova::operator()(const TriggerActivity& activity, std:
   // Yay! we have a trigger!
   if (m_activity.size() > m_threshold) {
 
-    detid_t detid = dunedaq::detdataformats::trigger::WHOLE_DETECTOR;
+    detid_t detid = dunedaq::trgdataformats::WHOLE_DETECTOR;
 
     TriggerCandidate tc;
     tc.time_start = time - 500'000'000; // time_start (10 seconds before the start of the activity)


### PR DESCRIPTION
As the first step of the FD/ND release split, `detdataformats` is split into several new packages:
1. `fddetdataformats`
2. `nddetdataformats`
3. `trgdataformats`

The split involves relocation of headers, rename of namespaces, and updates to C
MakeLists.txt and config.cmake.in

This PR contains the necessary changes as a result of the split.

