### PR TITLE
Changed default clock speed to 62.5 MHz

### DIFF
--- a/exec/run_trivial_candidate.cxx
+++ b/exec/run_trivial_candidate.cxx
@@ -23,7 +23,7 @@
 
 using namespace DuneTriggers;
 
-using pd_clock = std::chrono::duration<double, std::ratio<1, 50000000>>;
+using pd_clock = std::chrono::duration<double, std::ratio<1, 62500000>>;
 
 std::default_random_engine generator;
 

--- a/src/TriggerActivityMakerSupernova.cpp
+++ b/src/TriggerActivityMakerSupernova.cpp
@@ -11,7 +11,7 @@
 #include <chrono>
 #include <vector>
 
-using pd_clock = std::chrono::duration<double, std::ratio<1, 50000000>>;
+using pd_clock = std::chrono::duration<double, std::ratio<1, 62500000>>;
 using namespace triggeralgs;
 
 void

--- a/src/TriggerDecisionMakerSupernova.cpp
+++ b/src/TriggerDecisionMakerSupernova.cpp
@@ -13,7 +13,7 @@
 #include <limits>
 #include <vector>
 
-using pd_clock = std::chrono::duration<double, std::ratio<1, 50000000>>;
+using pd_clock = std::chrono::duration<double, std::ratio<1, 62500000>>;
 using namespace triggeralgs;
 
 void


### PR DESCRIPTION
The full set of repositories that are affected by this change is contained in the following list

```
git clone https://github.com/DUNE-DAQ/daqconf.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/dfmodules.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/dqm.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/flxlibs.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/hdf5libs.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/hsilibs.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/listrev.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/readoutmodules.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/timinglibs.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/trigger.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/triggeralgs.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/wibmod.git -b kbiery/62.5MHz_defaults
```

Recall that this first step in the deprecation of legacy hardware is simply switching to a default clock frequency of 62.5 MHz in our scripts, etc.  More changes will come later.