### PR TITLE
Changed kTPCDefault to kSimpleThreshold in test_factory.cxx

### DIFF
--- a/test/test_factory.cxx
+++ b/test/test_factory.cxx
@@ -29,7 +29,7 @@ BOOST_AUTO_TEST_CASE(test_macro_overview)
   TriggerPrimitive some_tp;
   for (int idx = 0; idx < 10; idx++) {
     some_tp.type = TriggerPrimitive::Type::kTPC;
-    some_tp.algorithm = TriggerPrimitive::Algorithm::kTPCDefault;
+    some_tp.algorithm = TriggerPrimitive::Algorithm::kSimpleThreshold;
     some_tp.time_start = idx;
     some_tp.time_peak = 1+idx;
     some_tp.time_over_threshold = 2;


### PR DESCRIPTION
One of several additional changes needed to react to [the change from a single TP Algorithm name to several of them with more descriptive names](https://github.com/DUNE-DAQ/trgdataformats/pull/10/files).