### PR TITLE
New ChannelDistance Algorithm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ find_package(detchannelmaps REQUIRED)
 add_library(triggeralgs SHARED
   src/TriggerActivityMakerADCSimpleWindow.cpp
   src/TriggerActivityMakerChannelDistance.cpp
+  src/TriggerCandidateMakerChannelDistance.cpp
   src/TriggerCandidateMakerADCSimpleWindow.cpp
   src/TriggerActivityMakerHorizontalMuon.cpp
   src/TriggerCandidateMakerHorizontalMuon.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ find_package(detchannelmaps REQUIRED)
 # provided by the trigger package)
 add_library(triggeralgs SHARED
   src/TriggerActivityMakerADCSimpleWindow.cpp
+  src/TriggerActivityMakerChannelDistance.cpp
   src/TriggerCandidateMakerADCSimpleWindow.cpp
   src/TriggerActivityMakerHorizontalMuon.cpp
   src/TriggerCandidateMakerHorizontalMuon.cpp

--- a/include/triggeralgs/ChannelDistance/TriggerActivityMakerChannelDistance.hpp
+++ b/include/triggeralgs/ChannelDistance/TriggerActivityMakerChannelDistance.hpp
@@ -24,7 +24,7 @@ class TriggerActivityMakerChannelDistance : public TriggerActivityMaker {
     void set_new_ta(const TriggerPrimitive& input_tp);
     TriggerActivity m_current_ta;
     uint32_t m_max_channel_distance = 50;
-    uint64_t m_max_time_delta = 8000;
+    uint64_t m_window_length = 8000;
     uint16_t m_min_tps = 20; // AEO: Type is arbitrary. Surprised even asking for 2^8 TPs.
     uint32_t m_current_lower_bound;
     uint32_t m_current_upper_bound;

--- a/include/triggeralgs/ChannelDistance/TriggerActivityMakerChannelDistance.hpp
+++ b/include/triggeralgs/ChannelDistance/TriggerActivityMakerChannelDistance.hpp
@@ -1,0 +1,35 @@
+/**
+ * @file TriggerActivityMakerChannelDistance.hpp
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2021.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#ifndef TRIGGERALGS_CHANNELDISTANCE_TRIGGERACTIVITYMAKERCHANNELDISTANCE_HPP_
+#define TRIGGERALGS_CHANNELDISTANCE_TRIGGERACTIVITYMAKERCHANNELDISTANCE_HPP_
+
+#include "triggeralgs/TriggerActivityFactory.hpp"
+#include <algorithm>
+
+namespace triggeralgs {
+
+class TriggerActivityMakerChannelDistance : public TriggerActivityMaker {
+  public:
+    void operator()(const TriggerPrimitive& input_tp, std::vector<TriggerActivity>& output_tas);
+    void configure(const nlohmann::json& config);
+    void set_ta_attributes();
+
+  private:
+    void set_new_ta(const TriggerPrimitive& input_tp);
+    TriggerActivity m_current_ta;
+    uint32_t m_max_channel_distance = 50;
+    uint64_t m_max_time_delta = 8000;
+    uint16_t m_min_tps = 20; // AEO: Type is arbitrary. Surprised even asking for 2^8 TPs.
+    uint32_t m_current_lower_bound;
+    uint32_t m_current_upper_bound;
+};
+
+} // namespace triggeralgs
+
+#endif // TRIGGERALGS_CHANNELDISTANCE_TRIGGERACTIVITYMAKERCHANNELDISTANCE_HPP_

--- a/include/triggeralgs/ChannelDistance/TriggerCandidateMakerChannelDistance.hpp
+++ b/include/triggeralgs/ChannelDistance/TriggerCandidateMakerChannelDistance.hpp
@@ -1,0 +1,32 @@
+/**
+ * @file TriggerCandidateMakerChannelDistance.hpp
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2021.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#ifndef TRIGGERALGS_CHANNELDISTANCE_TRIGGERCANDIDATEMAKERCHANNELDISTANCE_HPP_
+#define TRIGGERALGS_CHANNELDISTANCE_TRIGGERCANDIDATEMAKERCHANNELDISTANCE_HPP_
+
+#include "triggeralgs/TriggerCandidateFactory.hpp"
+#include <algorithm>
+
+namespace triggeralgs {
+
+class TriggerCandidateMakerChannelDistance : public TriggerCandidateMaker {
+  public:
+    void operator()(const TriggerActivity& input_ta, std::vector<TriggerCandidate>& output_tcs);
+    void configure(const nlohmann::json& config);
+    void set_tc_attributes();
+
+  private:
+    void set_new_tc(const TriggerActivity& input_ta);
+    TriggerCandidate m_current_tc;
+    uint16_t m_current_tp_count;
+    uint16_t m_max_tp_count = 1000; // Produce a TC when this count is exceeded. AEO: Arbitrary choice of 1000.
+};
+
+} // namespace triggeralgs
+
+#endif // TRIGGERALGS_CHANNELDISTANCE_TRIGGERCANDIDATEMAKERCHANNELDISTANCE_HPP_

--- a/src/TriggerActivityMakerChannelDistance.cpp
+++ b/src/TriggerActivityMakerChannelDistance.cpp
@@ -1,0 +1,102 @@
+/**
+ * @file TriggerActivityMakerChannelDistance.cpp
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2021.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#include "triggeralgs/ChannelDistance/TriggerActivityMakerChannelDistance.hpp"
+
+#include "TRACE/trace.h"
+#define TRACE_NAME "TriggerActivityMakerChannelDistancePlugin"
+
+#include <iostream>
+
+namespace triggeralgs {
+
+void
+TriggerActivityMakerChannelDistance::set_new_ta(const TriggerPrimitive& input_tp)
+{
+  m_current_ta = TriggerActivity();
+  m_current_ta.inputs.push_back(input_tp);
+  m_current_lower_bound = input_tp.channel - m_max_channel_distance;
+  m_current_upper_bound = input_tp.channel + m_max_channel_distance;
+  return;
+}
+
+void
+TriggerActivityMakerChannelDistance::operator()
+(const TriggerPrimitive& input_tp, std::vector<TriggerActivity>& output_tas)
+{
+  // Start a new TA if not already going.
+  if (m_current_ta.inputs.empty()) {
+    set_new_ta(input_tp);
+    return;
+  }
+
+  // Check to close the TA based on time.
+  if (input_tp.time_start - m_current_ta.inputs.front().time_start > m_max_time_delta) {
+    // Check to block the TA based on min TPs.
+    if (m_current_ta.inputs.size() >= m_min_tps) {
+      set_ta_attributes();
+      output_tas.push_back(m_current_ta);
+    }
+    set_new_ta(input_tp);
+    return;
+  }
+
+  // Check to skip the TP if it's outside the current channel bounds.
+  if (input_tp.channel > m_current_upper_bound || input_tp.channel < m_current_lower_bound)
+    return;
+
+  m_current_ta.inputs.push_back(input_tp);
+  m_current_lower_bound = std::min(m_current_lower_bound, input_tp.channel - m_max_channel_distance);
+  m_current_upper_bound = std::max(m_current_upper_bound, input_tp.channel + m_max_channel_distance);
+}
+
+void
+TriggerActivityMakerChannelDistance::configure(const nlohmann::json& config)
+{
+  if (config.contains("min_tps"))
+    m_min_tps = config["min_tps"];
+  if (config.contains("max_time_delta"))
+    m_max_time_delta = config["max_time_delta"];
+  if (config.contains("max_channel_distance"))
+    m_max_channel_distance = config["max_channel_distance"];
+
+  return;
+}
+
+void
+TriggerActivityMakerChannelDistance::set_ta_attributes()
+{
+  TriggerPrimitive first_tp = m_current_ta.inputs.front();
+  TriggerPrimitive last_tp = m_current_ta.inputs.back();
+
+  m_current_ta.channel_start = first_tp.channel;
+  m_current_ta.channel_end = last_tp.channel;
+
+  m_current_ta.time_start = first_tp.time_start;
+  m_current_ta.time_end = last_tp.time_start;
+
+  m_current_ta.detid = first_tp.detid;
+
+  m_current_ta.algorithm = TriggerActivity::Algorithm::kUnknown;
+  m_current_ta.type = TriggerActivity::Type::kTPC;
+
+  m_current_ta.adc_peak = 0;
+  for (const TriggerPrimitive& tp : m_current_ta.inputs) {
+    m_current_ta.adc_integral += tp.adc_integral;
+    if (tp.adc_peak <= m_current_ta.adc_peak) continue;
+    m_current_ta.adc_peak = tp.adc_peak;
+    m_current_ta.channel_peak = tp.channel;
+    m_current_ta.time_peak = tp.time_peak;
+  }
+  m_current_ta.time_activity = m_current_ta.time_peak;
+}
+
+// Register algo in TA Factory
+REGISTER_TRIGGER_ACTIVITY_MAKER(TRACE_NAME, TriggerActivityMakerChannelDistance)
+
+} // namespace triggeralgs

--- a/src/TriggerActivityMakerChannelDistance.cpp
+++ b/src/TriggerActivityMakerChannelDistance.cpp
@@ -11,8 +11,6 @@
 #include "TRACE/trace.h"
 #define TRACE_NAME "TriggerActivityMakerChannelDistancePlugin"
 
-#include <iostream>
-
 namespace triggeralgs {
 
 void
@@ -82,7 +80,7 @@ TriggerActivityMakerChannelDistance::set_ta_attributes()
 
   m_current_ta.detid = first_tp.detid;
 
-  m_current_ta.algorithm = TriggerActivity::Algorithm::kUnknown;
+  m_current_ta.algorithm = TriggerActivity::Algorithm::kChannelDistance;
   m_current_ta.type = TriggerActivity::Type::kTPC;
 
   m_current_ta.adc_peak = 0;

--- a/src/TriggerActivityMakerChannelDistance.cpp
+++ b/src/TriggerActivityMakerChannelDistance.cpp
@@ -34,7 +34,7 @@ TriggerActivityMakerChannelDistance::operator()
   }
 
   // Check to close the TA based on time.
-  if (input_tp.time_start - m_current_ta.inputs.front().time_start > m_max_time_delta) {
+  if (input_tp.time_start - m_current_ta.inputs.front().time_start > m_window_length) {
     // Check to block the TA based on min TPs.
     if (m_current_ta.inputs.size() >= m_min_tps) {
       set_ta_attributes();
@@ -58,8 +58,8 @@ TriggerActivityMakerChannelDistance::configure(const nlohmann::json& config)
 {
   if (config.contains("min_tps"))
     m_min_tps = config["min_tps"];
-  if (config.contains("max_time_delta"))
-    m_max_time_delta = config["max_time_delta"];
+  if (config.contains("window_length"))
+    m_window_length = config["window_length"];
   if (config.contains("max_channel_distance"))
     m_max_channel_distance = config["max_channel_distance"];
 

--- a/src/TriggerCandidateMakerChannelDistance.cpp
+++ b/src/TriggerCandidateMakerChannelDistance.cpp
@@ -1,0 +1,75 @@
+/**
+ * @file TriggerCandidateMakerChannelDistance.cpp
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2021.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#include "triggeralgs/ChannelDistance/TriggerCandidateMakerChannelDistance.hpp"
+
+#include "TRACE/trace.h"
+#define TRACE_NAME "TriggerCandidateMakerChannelDistancePlugin"
+
+namespace triggeralgs {
+
+void
+TriggerCandidateMakerChannelDistance::set_new_tc(const TriggerActivity& input_ta)
+{
+  m_current_tc = TriggerCandidate();
+  m_current_tc.inputs.push_back(input_ta);
+  m_current_tp_count = input_ta.inputs.size();
+  return;
+}
+
+void
+TriggerCandidateMakerChannelDistance::configure(const nlohmann::json& config)
+{
+  if (config.contains("max_tp_count"))
+    m_max_tp_count = config["max_tp_count"];
+  return;
+}
+
+void
+TriggerCandidateMakerChannelDistance::set_tc_attributes()
+{
+  auto& first_ta = m_current_tc.inputs.front();
+  auto& last_ta = m_current_tc.inputs.back();
+
+  m_current_tc.time_start = first_ta.time_start;
+  m_current_tc.time_end = last_ta.time_end;
+  m_current_tc.time_candidate = last_ta.time_start; // Since this is the TA that closed the TC.
+
+  m_current_tc.detid = first_ta.detid;
+  m_current_tc.algorithm = TriggerCandidate::Algorithm::kChannelDistance;
+  m_current_tc.type = TriggerCandidate::Type::kChannelDistance;
+  return;
+}
+
+void
+TriggerCandidateMakerChannelDistance::operator()(const TriggerActivity& input_ta, std::vector<TriggerCandidate>& output_tcs)
+{
+  // Start a new TC if not already going.
+  if (m_current_tc.inputs.empty()) {
+    set_new_tc(input_ta);
+    return;
+  }
+
+  // Check to close the TC based on TP contents.
+  if (input_ta.inputs.size() + m_current_tp_count > m_max_tp_count) {
+    set_tc_attributes();
+    output_tcs.push_back(m_current_tc);
+    set_new_tc(input_ta);
+    return;
+  }
+
+  // Append the new TA and increase the TP count.
+  m_current_tc.inputs.push_back(input_ta);
+  m_current_tp_count += input_ta.inputs.size();
+  return;
+}
+
+// Register algo in TC Factory
+REGISTER_TRIGGER_CANDIDATE_MAKER(TRACE_NAME, TriggerCandidateMakerChannelDistance)
+
+} // namespace triggeralgs


### PR DESCRIPTION
I've created a new TAMaker algorithm that makes comparisons using the TP channel, a maximum time window, and a minimum number of TPs. For any new TP:

1. Check that the difference in `time_start` for this new TP and the TA's first TP is below `m_max_time_delta` (configurable). Close the TA if so.
2. Check that it is within `m_max_channel_distance` (configurable) channels away from already included TPs for that TA. Include the new TP if so.
3. Check that a closed TA has at least `m_min_tps` (configurable) TPs. Include this TA if so.

This was tested through `process_tpstream.cxx` in `trgtools` and the replay application in `trigger` using the related PRs linked at the bottom. It has not been tested on live data. These resulting event displays use the default configuration for the TAMaker.

![channeldistance-9](https://github.com/DUNE-DAQ/triggeralgs/assets/5084895/560ffee4-003e-4927-b162-9907b69a5e94)
![channeldistance-97](https://github.com/DUNE-DAQ/triggeralgs/assets/5084895/15590189-5721-4a93-bf71-ed25e675bd15)
![channeldistance-132](https://github.com/DUNE-DAQ/triggeralgs/assets/5084895/3cc9bff9-4ae0-4729-98cb-29c5a74d7e81)

This is accompanied by a simple TCMaker that groups based on the number of TPs seen. If a new TA would increase the TP count above `m_max_tp_count` (configurable), then the TC is closed and included.

There are two related PRs: https://github.com/DUNE-DAQ/daqconf/pull/436 and https://github.com/DUNE-DAQ/trgdataformats/pull/12.