### PR TITLE
DBSCAN Format Update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ add_library(triggeralgs SHARED
   src/TriggerCandidateMakerSupernova.cpp
   src/TriggerDecisionMakerSupernova.cpp
   src/TriggerActivityMakerDBSCAN.cpp
+  src/TriggerCandidateMakerDBSCAN.cpp
   src/TAWindow.cpp
   src/TPWindow.cpp
   src/dbscan/dbscan.cpp

--- a/include/triggeralgs/dbscan/TriggerActivityMakerDBSCAN.hpp
+++ b/include/triggeralgs/dbscan/TriggerActivityMakerDBSCAN.hpp
@@ -25,6 +25,7 @@ public:
   void configure(const nlohmann::json &config);
   
 private:  
+  int m_eps{10};
   int m_min_pts{3}; // Minimum number of points to form a cluster
   timestamp_t m_first_timestamp{0};
   timestamp_t m_prev_timestamp{0};

--- a/include/triggeralgs/dbscan/TriggerCandidateMakerDBSCAN.hpp
+++ b/include/triggeralgs/dbscan/TriggerCandidateMakerDBSCAN.hpp
@@ -1,0 +1,35 @@
+/**
+ * @file TriggerCandidateMakerDBSCAN.hpp
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#ifndef TRIGGERALGS_DBSCAN_TRIGGERCANDIDATEMAKERDBSCAN_HPP_
+#define TRIGGERALGS_DBSCAN_TRIGGERCANDIDATEMAKERDBSCAN_HPP_
+
+#include "triggeralgs/TriggerCandidateFactory.hpp"
+#include "triggeralgs/dbscan/dbscan.hpp"
+
+#include <memory>
+#include <vector>
+
+namespace triggeralgs {
+class TriggerCandidateMakerDBSCAN : public TriggerCandidateMaker
+{
+
+public:
+  void operator()(const TriggerActivity& input_ta, std::vector<TriggerCandidate>& output_tc);
+  void configure(const nlohmann::json &config);
+
+private:
+  void set_new_tc(const TriggerActivity& input_ta);
+  void set_tc_attributes();
+  TriggerCandidate m_current_tc;
+  uint16_t m_current_tp_count;
+  uint16_t m_max_tp_count = 1000; // Produce a TC when this count is exceeded. AEO: Arbitrary choice of 1000.
+};
+} // namespace triggeralgs
+
+#endif // TRIGGERALGS_DBSCAN_TRIGGERCANDIDATEMAKERPRESCALE_HPP_

--- a/src/TriggerCandidateMakerDBSCAN.cpp
+++ b/src/TriggerCandidateMakerDBSCAN.cpp
@@ -1,0 +1,75 @@
+/**
+ * @file TriggerCandidateMakerDBSCAN.cpp
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2021.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#include "triggeralgs/dbscan/TriggerCandidateMakerDBSCAN.hpp"
+
+#include "TRACE/trace.h"
+#define TRACE_NAME "TriggerCandidateMakerDBSCANPlugin"
+
+namespace triggeralgs {
+
+void
+TriggerCandidateMakerDBSCAN::set_new_tc(const TriggerActivity& input_ta)
+{
+  m_current_tc = TriggerCandidate();
+  m_current_tc.inputs.push_back(input_ta);
+  m_current_tp_count = input_ta.inputs.size();
+  return;
+}
+
+void
+TriggerCandidateMakerDBSCAN::configure(const nlohmann::json& config)
+{
+  if (config.contains("max_tp_count"))
+    m_max_tp_count = config["max_tp_count"];
+  return;
+}
+
+void
+TriggerCandidateMakerDBSCAN::set_tc_attributes()
+{
+  auto& first_ta = m_current_tc.inputs.front();
+  auto& last_ta = m_current_tc.inputs.back();
+
+  m_current_tc.time_start = first_ta.time_start;
+  m_current_tc.time_end = last_ta.time_end;
+  m_current_tc.time_candidate = last_ta.time_start; // Since this is the TA that closed the TC.
+
+  m_current_tc.detid = first_ta.detid;
+  m_current_tc.algorithm = TriggerCandidate::Algorithm::kDBSCAN;
+  m_current_tc.type = TriggerCandidate::Type::kDBSCAN;
+  return;
+}
+
+void
+TriggerCandidateMakerDBSCAN::operator()(const TriggerActivity& input_ta, std::vector<TriggerCandidate>& output_tcs)
+{
+  // Start a new TC if not already going.
+  if (m_current_tc.inputs.empty()) {
+    set_new_tc(input_ta);
+    return;
+  }
+
+  // Check to close the TC based on TP contents.
+  if (input_ta.inputs.size() + m_current_tp_count > m_max_tp_count) {
+    set_tc_attributes();
+    output_tcs.push_back(m_current_tc);
+    set_new_tc(input_ta);
+    return;
+  }
+
+  // Append the new TA and increase the TP count.
+  m_current_tc.inputs.push_back(input_ta);
+  m_current_tp_count += input_ta.inputs.size();
+  return;
+}
+
+// Register algo in TC Factory.
+REGISTER_TRIGGER_CANDIDATE_MAKER(TRACE_NAME, TriggerCandidateMakerDBSCAN)
+
+} // namespace triggeralgs


### PR DESCRIPTION
This has a slight update to DBSCAN TAMaker to allow for the epsilon parameter to be configurable and includes a new TCMaker. This TCMaker is not complex and simply counts the number of TPs within the TAs and creates a new TC after some threshold. This is simply for the necessary labeling of a DBSCAN TCMaker.

This has related PRs in both https://github.com/DUNE-DAQ/daqconf/pull/438 and https://github.com/DUNE-DAQ/trgdataformats/pull/14.

I tested this with the `daqsystemtest`, `process_tpstream.cxx`, and the replay application in `trigger`. I ran into no problems and could access the data with the meaningful format changes.