### PR TITLE
New BundleN Algorithm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ find_package(detchannelmaps REQUIRED)
 add_library(triggeralgs SHARED
   src/TriggerActivityMakerADCSimpleWindow.cpp
   src/TriggerCandidateMakerADCSimpleWindow.cpp
+  src/TriggerCandidateMakerBundleN.cpp
   src/TriggerActivityMakerHorizontalMuon.cpp
   src/TriggerCandidateMakerHorizontalMuon.cpp
   src/TriggerCandidateMakerPlaneCoincidence.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ find_package(detchannelmaps REQUIRED)
 add_library(triggeralgs SHARED
   src/TriggerActivityMakerADCSimpleWindow.cpp
   src/TriggerCandidateMakerADCSimpleWindow.cpp
+  src/TriggerActivityMakerBundleN.cpp
   src/TriggerCandidateMakerBundleN.cpp
   src/TriggerActivityMakerHorizontalMuon.cpp
   src/TriggerCandidateMakerHorizontalMuon.cpp

--- a/include/triggeralgs/BundleN/TriggerActivityMakerBundleN.hpp
+++ b/include/triggeralgs/BundleN/TriggerActivityMakerBundleN.hpp
@@ -1,0 +1,32 @@
+/**
+ * @file TriggerActivityMakerBundleN.hpp
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#ifndef TRIGGERALGS_BUNDLEN_TRIGGERACTIVITYMAKERBUNDLEN_HPP_
+#define TRIGGERALGS_BUNDLEN_TRIGGERACTIVITYMAKERBUNDLEN_HPP_
+
+#include "triggeralgs/TriggerActivityFactory.hpp"
+
+#include <vector>
+
+namespace triggeralgs {
+
+class TriggerActivityMakerBundleN : public TriggerActivityMaker
+{
+  public:
+    void operator()(const TriggerPrimitive& input_tp, std::vector<TriggerActivity>& output_tas);
+    void configure(const nlohmann::json& config);
+    bool bundle_condition();
+
+  private:
+      uint64_t m_bundle_num = 1;
+      TriggerActivity m_current_ta;
+};
+
+} // namespace triggeralgs
+
+#endif // TRIGGERALGS_BUNDLEN_TRIGGERACTIVITYMAKERBUNDLEN_HPP_

--- a/include/triggeralgs/BundleN/TriggerActivityMakerBundleN.hpp
+++ b/include/triggeralgs/BundleN/TriggerActivityMakerBundleN.hpp
@@ -23,7 +23,7 @@ class TriggerActivityMakerBundleN : public TriggerActivityMaker
     bool bundle_condition();
 
   private:
-      uint64_t m_bundle_num = 1;
+      uint64_t m_bundle_size = 1;
       TriggerActivity m_current_ta;
 };
 

--- a/include/triggeralgs/BundleN/TriggerActivityMakerBundleN.hpp
+++ b/include/triggeralgs/BundleN/TriggerActivityMakerBundleN.hpp
@@ -25,6 +25,7 @@ class TriggerActivityMakerBundleN : public TriggerActivityMaker
   private:
       uint64_t m_bundle_size = 1;
       TriggerActivity m_current_ta;
+      void set_ta_attributes();
 };
 
 } // namespace triggeralgs

--- a/include/triggeralgs/BundleN/TriggerCandidateMakerBundleN.hpp
+++ b/include/triggeralgs/BundleN/TriggerCandidateMakerBundleN.hpp
@@ -25,6 +25,7 @@ class TriggerCandidateMakerBundleN : public TriggerCandidateMaker
   private:
       uint64_t m_bundle_size = 1;
       TriggerCandidate m_current_tc;
+      void set_tc_attributes();
 };
 
 } // namespace triggeralgs

--- a/include/triggeralgs/BundleN/TriggerCandidateMakerBundleN.hpp
+++ b/include/triggeralgs/BundleN/TriggerCandidateMakerBundleN.hpp
@@ -23,7 +23,7 @@ class TriggerCandidateMakerBundleN : public TriggerCandidateMaker
     bool bundle_condition();
 
   private:
-      uint64_t m_bundle_num = 1;
+      uint64_t m_bundle_size = 1;
       TriggerCandidate m_current_tc;
 };
 

--- a/include/triggeralgs/BundleN/TriggerCandidateMakerBundleN.hpp
+++ b/include/triggeralgs/BundleN/TriggerCandidateMakerBundleN.hpp
@@ -1,0 +1,32 @@
+/**
+ * @file TriggerCandidateMakerBundleN.hpp
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#ifndef TRIGGERALGS_BUNDLEN_TRIGGERCANDIDATEMAKERBUNDLEN_HPP_
+#define TRIGGERALGS_BUNDLEN_TRIGGERCANDIDATEMAKERBUNDLEN_HPP_
+
+#include "triggeralgs/TriggerCandidateFactory.hpp"
+
+#include <vector>
+
+namespace triggeralgs {
+
+class TriggerCandidateMakerBundleN : public TriggerCandidateMaker
+{
+  public:
+    void operator()(const TriggerActivity& input_ta, std::vector<TriggerCandidate>& output_tcs);
+    void configure(const nlohmann::json& config);
+    bool bundle_condition();
+
+  private:
+      uint64_t m_bundle_num = 1;
+      TriggerCandidate m_current_tc;
+};
+
+} // namespace triggeralgs
+
+#endif // TRIGGERALGS_BUNDLEN_TRIGGERCANDIDATEMAKERBUNDLEN_HPP_

--- a/src/TriggerActivityMakerBundleN.cpp
+++ b/src/TriggerActivityMakerBundleN.cpp
@@ -1,0 +1,113 @@
+/**
+ * @file TriggerActivityMakerBundleN.cpp
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#include "triggeralgs/BundleN/TriggerActivityMakerBundleN.hpp"
+
+#include "TRACE/trace.h"
+#define TRACE_NAME "TriggerActivityMakerBundleNPlugin"
+
+namespace triggeralgs {
+
+bool TriggerActivityMakerBundleN::bundle_condition() {
+  return m_current_ta.inputs.size() == m_bundle_num;
+}
+
+void
+TriggerActivityMakerBundleN::operator()(const TriggerPrimitive& input_tp, std::vector<TriggerActivity>& output_tas)
+{
+  // Expect that TPs are inherently time ordered.
+  m_current_ta.inputs.push_back(input_tp);
+
+  if (bundle_condition()) {
+    TLOG(TLVL_DEBUG_1) << "Emitting BundleNTriggerActivity with " << m_current_ta.inputs.size() << " TPs.";
+
+    // Using the first TA as reference.
+    TriggerPrimitive first_tp = m_current_ta.inputs.front();
+    TriggerPrimitive last_tp = m_current_ta.inputs.back();
+
+    m_current_ta.channel_start = first_tp.channel;
+    m_current_ta.channel_end = last_tp.channel;
+
+    m_current_ta.time_start = first_tp.time_start;
+    m_current_ta.time_end = last_tp.time_start;
+
+    m_current_ta.detid = first_tp.detid;
+
+    m_current_ta.algorithm = TriggerActivity::Algorithm::kUnknown;
+    m_current_ta.type = TriggerActivity::Type::kTPC;
+
+    m_current_ta.adc_peak = 0;
+    for (const TriggerPrimitive& tp : m_current_ta.inputs) {
+      m_current_ta.adc_integral += tp.adc_integral;
+      if (tp.adc_peak <= m_current_ta.adc_peak) continue;
+      m_current_ta.adc_peak = tp.adc_peak;
+      m_current_ta.channel_peak = tp.channel;
+      m_current_ta.time_peak = tp.time_peak;
+    }
+    m_current_ta.time_activity = m_current_ta.time_peak;
+
+    output_tas.push_back(m_current_ta);
+
+    // Reset the current.
+    m_current_ta = TriggerActivity();
+  }
+
+  // Should never reach this step. In this case, send it out.
+  if (m_current_ta.inputs.size() > m_bundle_num) {
+    TLOG(TLVL_DEBUG_1) << "Emitting large BundleN TriggerActivity with " << m_current_ta.inputs.size() << " TPs.";
+
+    // Using the first TA as reference.
+    TriggerPrimitive first_tp = m_current_ta.inputs.front();
+    TriggerPrimitive last_tp = m_current_ta.inputs.back();
+
+    m_current_ta.channel_start = first_tp.channel;
+    m_current_ta.channel_end = last_tp.channel;
+
+    m_current_ta.time_start = first_tp.time_start;
+    m_current_ta.time_end = last_tp.time_start;
+
+    m_current_ta.detid = first_tp.detid;
+
+    m_current_ta.algorithm = TriggerActivity::Algorithm::kUnknown;
+    m_current_ta.type = TriggerActivity::Type::kTPC;
+
+    m_current_ta.adc_peak = 0;
+    for (const TriggerPrimitive& tp : m_current_ta.inputs) {
+      m_current_ta.adc_integral += tp.adc_integral;
+      if (tp.adc_peak <= m_current_ta.adc_peak) continue;
+      m_current_ta.adc_peak = tp.adc_peak;
+      m_current_ta.channel_peak = tp.channel;
+      m_current_ta.time_peak = tp.time_peak;
+    }
+    m_current_ta.time_activity = m_current_ta.time_peak;
+
+    output_tas.push_back(m_current_ta);
+
+    // Reset the current.
+    m_current_ta = TriggerActivity();
+  }
+}
+
+void
+TriggerActivityMakerBundleN::configure(const nlohmann::json& config)
+{
+  if (config.is_object() && config.contains("bundle_number")) {
+    m_bundle_num = config["bundle_number"];
+
+    // TODO: Are we keeping these?
+//    if (config.contains("readout_window_ticks_before"))
+//      m_readout_window_ticks_before = config["readout_window_ticks_before"];
+//    if (config.contains("readout_window_ticks_after"))
+//      m_readout_window_ticks_after = config["readout_window_ticks_after"];
+  }
+  TLOG_DEBUG(TRACE_NAME) << "Using Activity bundle number " << m_bundle_num;
+}
+
+REGISTER_TRIGGER_ACTIVITY_MAKER(TRACE_NAME, TriggerActivityMakerBundleN)
+} // namespace triggeralgs
+

--- a/src/TriggerActivityMakerBundleN.cpp
+++ b/src/TriggerActivityMakerBundleN.cpp
@@ -24,8 +24,6 @@ TriggerActivityMakerBundleN::operator()(const TriggerPrimitive& input_tp, std::v
   m_current_ta.inputs.push_back(input_tp);
 
   if (bundle_condition()) {
-    TLOG(TLVL_DEBUG_1) << "Emitting BundleNTriggerActivity with " << m_current_ta.inputs.size() << " TPs.";
-
     // Using the first TA as reference.
     TriggerPrimitive first_tp = m_current_ta.inputs.front();
     TriggerPrimitive last_tp = m_current_ta.inputs.back();
@@ -38,7 +36,7 @@ TriggerActivityMakerBundleN::operator()(const TriggerPrimitive& input_tp, std::v
 
     m_current_ta.detid = first_tp.detid;
 
-    m_current_ta.algorithm = TriggerActivity::Algorithm::kUnknown;
+    m_current_ta.algorithm = TriggerActivity::Algorithm::kBundle;
     m_current_ta.type = TriggerActivity::Type::kTPC;
 
     m_current_ta.adc_peak = 0;
@@ -73,7 +71,7 @@ TriggerActivityMakerBundleN::operator()(const TriggerPrimitive& input_tp, std::v
 
     m_current_ta.detid = first_tp.detid;
 
-    m_current_ta.algorithm = TriggerActivity::Algorithm::kUnknown;
+    m_current_ta.algorithm = TriggerActivity::Algorithm::kBundle;
     m_current_ta.type = TriggerActivity::Type::kTPC;
 
     m_current_ta.adc_peak = 0;
@@ -98,14 +96,7 @@ TriggerActivityMakerBundleN::configure(const nlohmann::json& config)
 {
   if (config.is_object() && config.contains("bundle_number")) {
     m_bundle_num = config["bundle_number"];
-
-    // TODO: Are we keeping these?
-//    if (config.contains("readout_window_ticks_before"))
-//      m_readout_window_ticks_before = config["readout_window_ticks_before"];
-//    if (config.contains("readout_window_ticks_after"))
-//      m_readout_window_ticks_after = config["readout_window_ticks_after"];
   }
-  TLOG_DEBUG(TRACE_NAME) << "Using Activity bundle number " << m_bundle_num;
 }
 
 REGISTER_TRIGGER_ACTIVITY_MAKER(TRACE_NAME, TriggerActivityMakerBundleN)

--- a/src/TriggerActivityMakerBundleN.cpp
+++ b/src/TriggerActivityMakerBundleN.cpp
@@ -14,7 +14,7 @@
 namespace triggeralgs {
 
 bool TriggerActivityMakerBundleN::bundle_condition() {
-  return m_current_ta.inputs.size() == m_bundle_num;
+  return m_current_ta.inputs.size() == m_bundle_size;
 }
 
 void
@@ -56,7 +56,7 @@ TriggerActivityMakerBundleN::operator()(const TriggerPrimitive& input_tp, std::v
   }
 
   // Should never reach this step. In this case, send it out.
-  if (m_current_ta.inputs.size() > m_bundle_num) {
+  if (m_current_ta.inputs.size() > m_bundle_size) {
     TLOG(TLVL_DEBUG_1) << "Emitting large BundleN TriggerActivity with " << m_current_ta.inputs.size() << " TPs.";
 
     // Using the first TA as reference.
@@ -94,8 +94,8 @@ TriggerActivityMakerBundleN::operator()(const TriggerPrimitive& input_tp, std::v
 void
 TriggerActivityMakerBundleN::configure(const nlohmann::json& config)
 {
-  if (config.is_object() && config.contains("bundle_number")) {
-    m_bundle_num = config["bundle_number"];
+  if (config.is_object() && config.contains("bundle_size")) {
+    m_bundle_size = config["bundle_size"];
   }
 }
 

--- a/src/TriggerCandidateMakerBundleN.cpp
+++ b/src/TriggerCandidateMakerBundleN.cpp
@@ -24,8 +24,6 @@ TriggerCandidateMakerBundleN::operator()(const TriggerActivity& input_ta, std::v
   m_current_tc.inputs.push_back(input_ta);
 
   if (bundle_condition()) {
-    TLOG(TLVL_DEBUG_1) << "Emitting BundleNTriggerCandidate with " << m_current_tc.inputs.size() << " TAs.";
-
     // Using the first TA as reference.
     dunedaq::trgdataformats::TriggerActivityData front_ta = m_current_tc.inputs.front();
 
@@ -33,8 +31,8 @@ TriggerCandidateMakerBundleN::operator()(const TriggerActivity& input_ta, std::v
     m_current_tc.time_end = m_current_tc.inputs.back().time_end;
     m_current_tc.time_candidate = front_ta.time_start; // TODO: Conforming. Do we change this?
     m_current_tc.detid = front_ta.detid;
-    m_current_tc.type = TriggerCandidate::Type::kUnknown; // TODO: Change to a meaningful type.
-    m_current_tc.algorithm = TriggerCandidate::Algorithm::kCustom; // TODO: Make a kBundleN algo.
+    m_current_tc.type = TriggerCandidate::Type::kBundle;
+    m_current_tc.algorithm = TriggerCandidate::Algorithm::kBundle;
 
     output_tcs.push_back(m_current_tc);
 
@@ -54,8 +52,8 @@ TriggerCandidateMakerBundleN::operator()(const TriggerActivity& input_ta, std::v
     tc.time_end = m_current_tc.inputs.back().time_end;
     tc.time_candidate = front_ta.time_start; // TODO: Conforming. Do we change this?
     tc.detid = front_ta.detid;
-    tc.type = TriggerCandidate::Type::kUnknown; // TODO: Change to a meaningful type.
-    tc.algorithm = TriggerCandidate::Algorithm::kCustom; // TODO: Make a kBundleN algo.
+    tc.type = TriggerCandidate::Type::kBundle; // TODO: Change to a meaningful type.
+    tc.algorithm = TriggerCandidate::Algorithm::kBundle; // TODO: Make a kBundleN algo.
 
     output_tcs.push_back(tc);
 
@@ -69,14 +67,7 @@ TriggerCandidateMakerBundleN::configure(const nlohmann::json& config)
 {
   if (config.is_object() && config.contains("bundle_number")) {
     m_bundle_num = config["bundle_number"];
-
-    // TODO: Are we keeping these?
-//    if (config.contains("readout_window_ticks_before"))
-//      m_readout_window_ticks_before = config["readout_window_ticks_before"];
-//    if (config.contains("readout_window_ticks_after"))
-//      m_readout_window_ticks_after = config["readout_window_ticks_after"];
   }
-  TLOG_DEBUG(TRACE_NAME) << "Using Candidate bundle number " << m_bundle_num;
 }
 
 REGISTER_TRIGGER_CANDIDATE_MAKER(TRACE_NAME, TriggerCandidateMakerBundleN)

--- a/src/TriggerCandidateMakerBundleN.cpp
+++ b/src/TriggerCandidateMakerBundleN.cpp
@@ -1,0 +1,84 @@
+/**
+ * @file TriggerCandidateMakerBundleN.cpp
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#include "triggeralgs/BundleN/TriggerCandidateMakerBundleN.hpp"
+
+#include "TRACE/trace.h"
+#define TRACE_NAME "TriggerCandidateMakerBundleNPlugin"
+
+namespace triggeralgs {
+
+bool TriggerCandidateMakerBundleN::bundle_condition() {
+  return m_current_tc.inputs.size() == m_bundle_num;
+}
+
+void
+TriggerCandidateMakerBundleN::operator()(const TriggerActivity& input_ta, std::vector<TriggerCandidate>& output_tcs)
+{
+  // Expect that TAs are inherently time ordered.
+  m_current_tc.inputs.push_back(input_ta);
+
+  if (bundle_condition()) {
+    TLOG(TLVL_DEBUG_1) << "Emitting BundleNTriggerCandidate with " << m_current_tc.inputs.size() << " TAs.";
+
+    // Using the first TA as reference.
+    dunedaq::trgdataformats::TriggerActivityData front_ta = m_current_tc.inputs.front();
+
+    m_current_tc.time_start = front_ta.time_start;
+    m_current_tc.time_end = m_current_tc.inputs.back().time_end;
+    m_current_tc.time_candidate = front_ta.time_start; // TODO: Conforming. Do we change this?
+    m_current_tc.detid = front_ta.detid;
+    m_current_tc.type = TriggerCandidate::Type::kUnknown; // TODO: Change to a meaningful type.
+    m_current_tc.algorithm = TriggerCandidate::Algorithm::kCustom; // TODO: Make a kBundleN algo.
+
+    output_tcs.push_back(m_current_tc);
+
+    // Reset the current.
+    m_current_tc = TriggerCandidate();
+  }
+
+  // Should never reach this step. In this case, send it out.
+  if (m_current_tc.inputs.size() > m_bundle_num) {
+    TLOG(TLVL_DEBUG_1) << "Emitting large BundleN TriggerCandidate with " << m_current_tc.inputs.size() << " TAs.";
+
+    // Using the first TA as reference.
+    dunedaq::trgdataformats::TriggerActivityData front_ta = m_current_tc.inputs.front();
+
+    TriggerCandidate tc;
+    tc.time_start = front_ta.time_start;
+    tc.time_end = m_current_tc.inputs.back().time_end;
+    tc.time_candidate = front_ta.time_start; // TODO: Conforming. Do we change this?
+    tc.detid = front_ta.detid;
+    tc.type = TriggerCandidate::Type::kUnknown; // TODO: Change to a meaningful type.
+    tc.algorithm = TriggerCandidate::Algorithm::kCustom; // TODO: Make a kBundleN algo.
+
+    output_tcs.push_back(tc);
+
+    // Reset the current.
+    m_current_tc = TriggerCandidate();
+  }
+}
+
+void
+TriggerCandidateMakerBundleN::configure(const nlohmann::json& config)
+{
+  if (config.is_object() && config.contains("bundle_number")) {
+    m_bundle_num = config["bundle_number"];
+
+    // TODO: Are we keeping these?
+//    if (config.contains("readout_window_ticks_before"))
+//      m_readout_window_ticks_before = config["readout_window_ticks_before"];
+//    if (config.contains("readout_window_ticks_after"))
+//      m_readout_window_ticks_after = config["readout_window_ticks_after"];
+  }
+  TLOG_DEBUG(TRACE_NAME) << "Using Candidate bundle number " << m_bundle_num;
+}
+
+REGISTER_TRIGGER_CANDIDATE_MAKER(TRACE_NAME, TriggerCandidateMakerBundleN)
+} // namespace triggeralgs
+

--- a/src/TriggerCandidateMakerBundleN.cpp
+++ b/src/TriggerCandidateMakerBundleN.cpp
@@ -14,7 +14,7 @@
 namespace triggeralgs {
 
 bool TriggerCandidateMakerBundleN::bundle_condition() {
-  return m_current_tc.inputs.size() == m_bundle_num;
+  return m_current_tc.inputs.size() == m_bundle_size;
 }
 
 void
@@ -41,7 +41,7 @@ TriggerCandidateMakerBundleN::operator()(const TriggerActivity& input_ta, std::v
   }
 
   // Should never reach this step. In this case, send it out.
-  if (m_current_tc.inputs.size() > m_bundle_num) {
+  if (m_current_tc.inputs.size() > m_bundle_size) {
     TLOG(TLVL_DEBUG_1) << "Emitting large BundleN TriggerCandidate with " << m_current_tc.inputs.size() << " TAs.";
 
     // Using the first TA as reference.
@@ -65,8 +65,8 @@ TriggerCandidateMakerBundleN::operator()(const TriggerActivity& input_ta, std::v
 void
 TriggerCandidateMakerBundleN::configure(const nlohmann::json& config)
 {
-  if (config.is_object() && config.contains("bundle_number")) {
-    m_bundle_num = config["bundle_number"];
+  if (config.is_object() && config.contains("bundle_size")) {
+    m_bundle_size = config["bundle_size"];
   }
 }
 


### PR DESCRIPTION
This algorithm simply bundles by a given parameter `bundle_number`. Once a TA/TC reaches that `bundle_number`, that TA/TC is outputted and a new one is started.

This is primarily a debugging algorithm as it helps control one degree of freedom at a time. For example, one could set any TAMaker with the BundleN TCMaker at a high `bundle_number` to keep a low rate of TCs while still collecting all TAs.

This has related PRs in both https://github.com/DUNE-DAQ/daqconf/pull/439 and https://github.com/DUNE-DAQ/trgdataformats/pull/15.

This was tested extensively with `process_tpstream.cxx` and the replay application in `trigger` and it was tested to a lesser extent with `daqsystemtest`. In all cases, the algorithm achieved the expected number `bundle_number` and the results had no obvious wrongness.