### PR TITLE
Channel-time adjacency algorithm implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,8 @@ add_library(triggeralgs SHARED
   src/TriggerCandidateMakerDBSCAN.cpp
   src/TriggerActivityMakerChannelAdjacency.cpp
   src/TriggerCandidateMakerChannelAdjacency.cpp
+  src/TriggerActivityMakerChannelTimeAdjacency.cpp
+  src/TriggerCandidateMakerChannelTimeAdjacency.cpp
   src/TAWindow.cpp
   src/TPWindow.cpp
   src/dbscan/dbscan.cpp

--- a/include/triggeralgs/ChannelTimeAdjacency/README.md
+++ b/include/triggeralgs/ChannelTimeAdjacency/README.md
@@ -1,0 +1,17 @@
+# ChannelTimeAdjacency Algorithm
+
+The ChannelTimeAdjacency algorithm is an enhanced version of the adjacency algorithm implemented for the HorizontalMuon algorithm, specifically focusing on the TA maker part.
+
+## Overview
+
+The algorithm constructs Trigger Activities (TAs) by analyzing Trigger Primitives (TPs) within a given time window. TAs are formed by grouping TPs that represent an activity or track, excluding background/outliers. The longest track is stored in the time window.
+
+## Key Features
+
+- Improved version of the adjacency logic present at the HorizontalMuon algorithm.
+- Constructs TAs based on TPs within a TP window that have a channel-time correlation.
+- Excludes background/outliers from TAs.
+
+## References
+
+- [Adjacency trigger refinement by Hamza Amar Es-sghir (IFIC-Valencia, Spain)](https://indico.fnal.gov/event/64229/)

--- a/include/triggeralgs/ChannelTimeAdjacency/TriggerActivityMakerChannelTimeAdjacency.hpp
+++ b/include/triggeralgs/ChannelTimeAdjacency/TriggerActivityMakerChannelTimeAdjacency.hpp
@@ -30,13 +30,13 @@ private:
   TPWindow m_longest_track_window;      // Holds collection hits only for the longest track of the current window provided the adjacency threshold is exceeded
   uint64_t m_primitive_count = 0;       
   uint16_t m_fragment_count = 0;        // Fragment counter
-  uint16_t m_time_tolerance = 150;      // Time tolerance, in ticks, to filter out TPs not correlated in time in the saved TA for the longest track.
 
   // Configurable parameters.
   bool m_print_tp_info = false;          // Prints out some information on every TP received
   uint16_t m_adjacency_threshold = 15;   // Default is 15 wire track for testing
   int m_max_adjacency = 0;               // The maximum adjacency seen so far in any window
   uint16_t m_adj_tolerance = 3;          // Adjacency tolerance - default is 3 from coldbox testing.
+  uint16_t m_time_tolerance = 150;      // Time tolerance, in ticks, to filter out TPs not correlated in time in the saved TA for the longest track.
   timestamp_t m_window_length = 8000;    // Shouldn't exceed the max drift which is ~9375 62.5 MHz ticks for VDCB
   uint16_t m_ta_count = 0;               // Use for prescaling
   uint16_t m_prescale = 1;               // Prescale value, defult is one, trigger every TA

--- a/include/triggeralgs/ChannelTimeAdjacency/TriggerActivityMakerChannelTimeAdjacency.hpp
+++ b/include/triggeralgs/ChannelTimeAdjacency/TriggerActivityMakerChannelTimeAdjacency.hpp
@@ -1,0 +1,52 @@
+/**
+ * @file TriggerActivityMakerChannelTimeAdjacency.hpp
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2021.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#ifndef TRIGGERALGS_CHANNELTIMEADJACENCY_TRIGGERACTIVITYMAKERCHANNELTIMEADJACENCY_HPP_
+#define TRIGGERALGS_CHANNELTIMEADJACENCY_TRIGGERACTIVITYMAKERCHANNELTIMEADJACENCY_HPP_
+
+#include "triggeralgs/TPWindow.hpp"
+#include "triggeralgs/TriggerActivityFactory.hpp"
+#include <fstream>
+#include <vector>
+
+namespace triggeralgs {
+class TriggerActivityMakerChannelTimeAdjacency : public TriggerActivityMaker
+{
+public:
+  void operator()(const TriggerPrimitive& input_tp, std::vector<TriggerActivity>& output_ta);
+  void configure(const nlohmann::json& config);
+
+private:
+  TriggerActivity construct_ta() const;
+
+  uint16_t check_adjacency();     // Returns longest string of adjacent collection hits in window
+
+  TPWindow m_current_window;            // Holds collection hits only
+  TPWindow m_longest_track_window;      // Holds collection hits only for the longest track of the current window provided the adjacency threshold is exceeded
+  uint64_t m_primitive_count = 0;       
+  uint16_t m_fragment_count = 0;        // Fragment counter
+  uint16_t m_time_tolerance = 150;      // Time tolerance, in ticks, to filter out TPs not correlated in time in the saved TA for the longest track.
+
+  // Configurable parameters.
+  bool m_print_tp_info = false;          // Prints out some information on every TP received
+  uint16_t m_adjacency_threshold = 15;   // Default is 15 wire track for testing
+  int m_max_adjacency = 0;               // The maximum adjacency seen so far in any window
+  uint16_t m_adj_tolerance = 3;          // Adjacency tolerance - default is 3 from coldbox testing.
+  timestamp_t m_window_length = 8000;    // Shouldn't exceed the max drift which is ~9375 62.5 MHz ticks for VDCB
+  uint16_t m_ta_count = 0;               // Use for prescaling
+  uint16_t m_prescale = 1;               // Prescale value, defult is one, trigger every TA
+
+  // For debugging and performance study purposes
+  void add_window_to_record(TPWindow window);
+  void dump_window_record();
+  void dump_longest_track_record_channel_ordered();
+  void dump_longest_track_record_time_ordered();
+  std::vector<TPWindow> m_window_record;
+};
+} // namespace triggeralgs
+#endif // TRIGGERALGS_CHANNELTIMEADJACENCY_TRIGGERACTIVITYMAKERCHANNELTIMEADJACENCY_HPP_

--- a/include/triggeralgs/ChannelTimeAdjacency/TriggerActivityMakerChannelTimeAdjacency.hpp
+++ b/include/triggeralgs/ChannelTimeAdjacency/TriggerActivityMakerChannelTimeAdjacency.hpp
@@ -24,19 +24,19 @@ public:
 private:
   TriggerActivity construct_ta() const;
 
-  uint16_t check_adjacency();     // Returns longest string of adjacent collection hits in window
+  uint16_t check_adjacency();         // Returns longest string of adjacent collection hits in window
 
-  TPWindow m_current_window;            // Holds collection hits only
-  TPWindow m_longest_track_window;      // Holds collection hits only for the longest track of the current window provided the adjacency threshold is exceeded
-  uint64_t m_primitive_count = 0;       
-  uint16_t m_fragment_count = 0;        // Fragment counter
+  TPWindow m_current_window;          // Holds collection hits only
+  TPWindow m_longest_track_window;    // Holds collection hits only for the longest track of the current window provided the adjacency threshold is exceeded
+  uint64_t m_primitive_count = 0;     
+  uint16_t m_fragment_count = 0;      // Fragment counter
 
   // Configurable parameters.
   bool m_print_tp_info = false;          // Prints out some information on every TP received
   uint16_t m_adjacency_threshold = 15;   // Default is 15 wire track for testing
   int m_max_adjacency = 0;               // The maximum adjacency seen so far in any window
   uint16_t m_adj_tolerance = 3;          // Adjacency tolerance - default is 3 from coldbox testing.
-  uint16_t m_time_tolerance = 150;      // Time tolerance, in ticks, to filter out TPs not correlated in time in the saved TA for the longest track.
+  uint16_t m_time_tolerance = 150;       // Time tolerance, in ticks, to filter out TPs not correlated in time in the saved TA for the longest track.
   timestamp_t m_window_length = 8000;    // Shouldn't exceed the max drift which is ~9375 62.5 MHz ticks for VDCB
   uint16_t m_ta_count = 0;               // Use for prescaling
   uint16_t m_prescale = 1;               // Prescale value, defult is one, trigger every TA

--- a/include/triggeralgs/ChannelTimeAdjacency/TriggerCandidateMakerChannelTimeAdjacency.hpp
+++ b/include/triggeralgs/ChannelTimeAdjacency/TriggerCandidateMakerChannelTimeAdjacency.hpp
@@ -1,0 +1,49 @@
+/**
+ * @file TriggerCandidateMakerChannelTimeAdjacency.hpp
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2021.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#ifndef TRIGGERALGS_ChannelTimeAdjacency_TRIGGERCANDIDATEMAKERChannelTimeAdjacency_HPP_
+#define TRIGGERALGS_ChannelTimeAdjacency_TRIGGERCANDIDATEMAKERChannelTimeAdjacency_HPP_
+
+#include "triggeralgs/TriggerCandidateFactory.hpp"
+#include "triggeralgs/TAWindow.hpp"
+
+#include <fstream>
+#include <vector>
+
+namespace triggeralgs {
+class TriggerCandidateMakerChannelTimeAdjacency : public TriggerCandidateMaker
+{
+
+public:
+  // The function that gets called when there is a new activity
+  void operator()(const TriggerActivity&, std::vector<TriggerCandidate>&);
+  void configure(const nlohmann::json& config);
+
+private:
+
+  TriggerCandidate construct_tc() const;
+
+  TAWindow m_current_window;
+  uint64_t m_activity_count = 0; // NOLINT(build/unsigned)
+
+  // Configurable parameters.
+  bool m_trigger_on_adc = false;
+  bool m_trigger_on_n_channels = false;
+  uint32_t m_adc_threshold = 1200000;
+  uint16_t m_n_channels_threshold = 600; // 80ish for frames, O(200 - 600) for tpslink
+  timestamp_t m_window_length = 80000;
+  timestamp_t m_readout_window_ticks_before = 32768;
+  timestamp_t m_readout_window_ticks_after = 32768;
+  int m_tc_number = 0;
+
+  // For debugging purposes.
+  void add_window_to_record(TAWindow window);
+  std::vector<TAWindow> m_window_record;
+};
+} // namespace triggeralgs
+#endif // TRIGGERALGS_ChannelTimeAdjacency_TRIGGERCANDIDATEMAKERChannelTimeAdjacency_HPP_

--- a/src/TriggerActivityMakerChannelTimeAdjacency.cpp
+++ b/src/TriggerActivityMakerChannelTimeAdjacency.cpp
@@ -1,0 +1,353 @@
+/**
+ * @file TriggerActivityMakerChannelTimeAdjacency.cpp
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2021.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#include "triggeralgs/ChannelTimeAdjacency/TriggerActivityMakerChannelTimeAdjacency.hpp"
+#include "triggeralgs/Logging.hpp"
+#include "TRACE/trace.h"
+#define TRACE_NAME "TriggerActivityMakerChannelTimeAdjacencyPlugin"
+#include <vector>
+#include <math.h>
+
+using namespace triggeralgs;
+
+using Logging::TLVL_DEBUG_LOW;
+
+void
+TriggerActivityMakerChannelTimeAdjacency::operator()(const TriggerPrimitive& input_tp,
+					     std::vector<TriggerActivity>& output_ta)
+{
+
+  uint16_t adjacency;
+
+  // Add useful info about recived TPs here for FW and SW TPG guys.
+  if (m_print_tp_info){
+    TLOG(1) << "TP Start Time: " << input_tp.time_start << ", TP ADC Sum: " <<  input_tp.adc_integral
+	    << ", TP TOT: " << input_tp.time_over_threshold << ", TP ADC Peak: " << input_tp.adc_peak
+     	    << ", TP Offline Channel ID: " << input_tp.channel;
+    TLOG(1) << "Adjacency of current window is: " << check_adjacency();    
+  }
+
+
+  // 0) FIRST TP =====================================================================
+  // The first time operator() is called, reset the window object.
+  if (m_current_window.is_empty()) {
+    m_current_window.reset(input_tp);
+    m_primitive_count++;
+    m_longest_track_window.clear();
+    return;
+  }
+
+  // If the difference between the current TP's start time and the start of the window
+  // is less than the specified window size, add the TP to the window.
+  if ((input_tp.time_start - m_current_window.time_start) < m_window_length) {
+    m_current_window.add(input_tp);
+  }
+
+  // 1) ADJACENCY THRESHOLD EXCEEDED ==================================================
+  // If the addition of the current TP to the window would make it longer than the
+  // specified window length, don't add it but check whether the adjacency of the
+  // current window exceeds the configured threshold. If it does, and we are triggering
+  // on adjacency, then create a TA and reset the window with the new/current TP.
+  else if ((adjacency = check_adjacency()) > m_adjacency_threshold) {
+    m_ta_count++;
+    if (m_ta_count % m_prescale == 0){   
+
+    	// Check for a new maximum, display the largest seen adjacency in the log.
+    	if (adjacency > m_max_adjacency) { m_max_adjacency = adjacency; }
+    	TLOG_DEBUG(TRACE_NAME) << "Emitting track and multiplicity TA with adjacency " << check_adjacency() <<
+                   " and multiplicity " << m_longest_track_window.n_channels_hit() << ". The ADC integral of this TA is " << 
+                   m_longest_track_window.adc_integral << " and the largest longest track seen so far is " << m_max_adjacency;
+
+      output_ta.push_back(construct_ta());
+    	m_current_window.reset(input_tp);
+     }
+  }
+
+  // 2) Otherwise, slide the window along using the current TP.
+  else {
+    m_current_window.move(input_tp, m_window_length);
+    m_longest_track_window.clear();  
+  }
+
+  using namespace std::chrono;
+  // If this is the first TP of the run, calculate the initial offset:
+  if (m_primitive_count == 0){
+   m_initial_offset = duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count() - input_tp.time_start*16*1e-6;
+  }
+  
+  // Update OpMon Variable(s)
+  uint64_t system_time = duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
+  uint64_t data_time = input_tp.time_start*16*1e-6;                              // Convert 62.5 MHz ticks to ms
+  m_data_vs_system_time.store(fabs(system_time - data_time - m_initial_offset)); // Store the difference for OpMon*/
+  m_primitive_count++;
+
+  return;
+}
+
+void
+TriggerActivityMakerChannelTimeAdjacency::configure(const nlohmann::json& config)
+{
+  if (config.is_object()) {
+    if (config.contains("time_tolerance"))
+      m_time_tolerance = config["time_tolerance"];
+    if (config.contains("window_length"))
+      m_window_length = config["window_length"];
+    if (config.contains("adj_tolerance"))
+      m_adj_tolerance = config["adj_tolerance"];
+    if (config.contains("adjacency_threshold"))
+      m_adjacency_threshold = config["adjacency_threshold"];
+    if (config.contains("print_tp_info"))
+      m_print_tp_info = config["print_tp_info"];
+    if (config.contains("prescale"))
+      m_prescale = config["prescale"]; 
+ }
+
+}
+
+TriggerActivity
+TriggerActivityMakerChannelTimeAdjacency::construct_ta() const
+{
+
+  TriggerActivity ta;
+  
+  TriggerPrimitive last_tp = m_longest_track_window.inputs.back();
+
+  ta.time_start = last_tp.time_start;
+  ta.time_end = last_tp.time_start+last_tp.time_over_threshold;
+  ta.time_peak = last_tp.time_peak;
+  ta.time_activity = last_tp.time_peak;
+  ta.channel_start = last_tp.channel;
+  ta.channel_end = last_tp.channel;
+  ta.channel_peak = last_tp.channel;
+  ta.adc_integral = m_longest_track_window.adc_integral;
+  ta.adc_peak = last_tp.adc_integral;
+  ta.detid = last_tp.detid;
+  ta.type = TriggerActivity::Type::kTPC;
+  ta.algorithm = TriggerActivity::Algorithm::kChannelTimeAdjacency;
+  ta.inputs = m_longest_track_window.inputs;
+
+
+  for( const auto& tp : ta.inputs ) {
+    ta.time_start = std::min(ta.time_start, tp.time_start);
+    ta.time_end = std::max(ta.time_end, tp.time_start+tp.time_over_threshold);
+    ta.channel_start = std::min(ta.channel_start, tp.channel);
+    ta.channel_end = std::max(ta.channel_end, tp.channel);
+    if (tp.adc_peak > ta.adc_peak) {
+      ta.time_peak = tp.time_peak;
+      ta.adc_peak = tp.adc_peak;
+      ta.channel_peak = tp.channel;
+    }
+  }
+
+  return ta;
+}
+
+uint16_t
+TriggerActivityMakerChannelTimeAdjacency::check_adjacency() 
+{
+  uint16_t adj = 1;              // Initialize adjacency, 1 for the first wire
+  uint16_t max = 0;              // Maximum adjacency of window, which this function returns
+  unsigned int channel_diff;     // Channel difference between to consecutive TPs of a ChannelID ordered TP vector
+  unsigned int index;            // Index of the previous TP satisfying the adjacency condition
+  int64_t start_time_diff;       // Start time difference between to consecutive TPs of a ChannelID ordered TP vector
+  unsigned int tol_count = 0;    // Tolerance count, should not pass adj_tolerance
+
+  std::vector<TriggerPrimitive> tp_inputs = m_current_window.inputs;
+  std::vector<TriggerPrimitive> tp_track;
+  std::vector<TriggerPrimitive> tp_longest_track;
+
+  // Generate a channelID ordered list of hit channels for this window: m_current_window
+  std::sort(tp_inputs.begin(), tp_inputs.end(), [](const TriggerPrimitive& tp1, const TriggerPrimitive& tp2) {
+    return tp1.channel < tp2.channel;
+  });
+
+  // Loop over the TPs of the current window
+  for (unsigned int i=0; i < tp_inputs.size(); i++){
+    // Initiate/Resume the search with the first/a TP of the current window
+    tp_track.push_back(tp_inputs.at(i));
+    // index corresponds to the position of the latest TP of the current track
+    index = i;
+    unsigned int j=i+1; // j index to compare TPs further than the TP at position index
+    channel_diff = 0; // To access the while loop for every iteration of i
+    // Loop over the TPs of the current window to find the longest track
+    while (j < tp_inputs.size() && (channel_diff == 1 || channel_diff == 0)){
+      channel_diff = tp_inputs.at(j).channel - tp_inputs.at(index).channel;
+      start_time_diff = std::abs(static_cast<int64_t>(tp_inputs.at(j).time_start) - static_cast<int64_t>(tp_inputs.at(index).time_start));
+      // Check adjacency from that TP at position i. Add next TP and adjacency if the condition is fulfilled
+      if (channel_diff == 1 && start_time_diff < m_time_tolerance){
+        tp_track.push_back(tp_inputs.at(j));
+        adj++;
+        index = j;
+      }
+      // Check adjacency from TP at position i. Add only next TP if the condition is fulfilled
+      else if (channel_diff == 0 && start_time_diff < m_time_tolerance){
+        tp_track.push_back(tp_inputs.at(j));
+        index = j;
+      }
+
+      // If next channel is not on the next hit, but the 'second next', increase adjacency 
+      // but also tally up with the tolerance counter.
+      else if ((channel_diff <= 5 && start_time_diff < channel_diff*m_time_tolerance) && (tol_count < m_adj_tolerance)) {
+        tp_track.push_back(tp_inputs.at(j));
+        adj++;
+        index = j;
+        tol_count = channel_diff - 1;
+        channel_diff = 0; // To stay in the while loop
+      }
+      // else if (((channel_diff == 2 && start_time_diff < 2*m_time_tolerance) || (channel_diff == 3 && start_time_diff < 3*m_time_tolerance) 
+      // || (channel_diff == 4 && start_time_diff < 4*m_time_tolerance) || (channel_diff == 5 && start_time_diff < 5*m_time_tolerance))
+      //         && (tol_count < m_adj_tolerance)) {
+      //   tp_track.push_back(tp_inputs.at(j));
+      //   adj++;
+      //   index = j;
+
+      //   for (unsigned int i = 0 ; i < channel_diff ; i++) tol_count++;
+      //   channel_diff = 0; // To stay in the while loop
+      // }
+
+      j++;
+    } // End of while loop
+
+    // Verify if new adjacency exceeds the max value. If so, max and tp_longest_track are updated. 
+    if(adj > max){ 
+      max = adj;
+      tp_longest_track = tp_track;
+    }
+    // Update the counter and reset tp_track (TP vector)
+    adj = 1;
+    tp_track.clear();
+  } // End of for loop
+
+  // Add the TPs that caused the adjacency to be the global maximum after channel-time filtering
+  for (auto tp : tp_longest_track) {
+    m_longest_track_window.add(tp);
+  }
+
+  return max;
+}
+
+//////////////////////////////////////////////////
+// For debugging and performance study purposes // 
+//////////////////////////////////////////////////
+
+void
+TriggerActivityMakerChannelTimeAdjacency::add_window_to_record(TPWindow window)
+{
+  m_window_record.push_back(window);
+  return;
+}
+
+void
+TriggerActivityMakerChannelTimeAdjacency::dump_window_record()
+{
+  // To output the window sizes and quotient into a file for debugging purposes
+  uint16_t longestTrackSize, currentWindowSize;
+  double quotient;
+  
+  // Output the window sizes to a file
+  std::ofstream outputFile("window_sizes_time_filtered.txt", std::ios::app);
+  if (outputFile.is_open()) {
+    // Check if it's the first row (first fragment) and write the variable names
+    if (m_fragment_count==0) {
+      outputFile << "LongestTrackSize,CurrentWindowSize,Quotient(%)" << std::endl;
+    }
+
+    // Write the window sizes and quotient
+    longestTrackSize = m_longest_track_window.inputs.size();
+    currentWindowSize = m_current_window.inputs.size();
+    quotient = static_cast<double>(longestTrackSize) / currentWindowSize * 100;
+
+    outputFile << longestTrackSize << "," << currentWindowSize << "," << quotient << std::endl;
+
+    outputFile.close();
+  } else {
+    std::cerr << "Unable to open the output file." << std::endl;
+  }
+}
+
+void
+TriggerActivityMakerChannelTimeAdjacency::dump_longest_track_record_channel_ordered()
+{
+  // Output the TP info of the longest track to a file
+  std::ofstream tpInfoFile("tp_info_longest_track_time_filtered.txt", std::ios::app);
+  if (tpInfoFile.is_open()) {
+    if (m_fragment_count == 0) {
+      tpInfoFile << "Longest Track TP Information" << std::endl;
+      tpInfoFile << "TP index, Channel, Relative Start Time (ticks), Relative Time Difference (ticks)" << std::endl;
+    }
+    
+    tpInfoFile << "Fragment number: " << m_fragment_count << std::endl;
+
+    // Calculate the minimum start time
+    timestamp_t minStartTime = std::numeric_limits<timestamp_t>::max();
+    if (!m_longest_track_window.inputs.empty()) {
+      minStartTime = std::min_element(m_longest_track_window.inputs.begin(), m_longest_track_window.inputs.end(),
+        [](const auto& tp1, const auto& tp2) {
+          return tp1.time_start < tp2.time_start;
+        })->time_start;
+    }
+
+    int tp_index = 0;
+    TriggerPrimitive tp_former;
+    for (const auto& tp : m_longest_track_window.inputs) {
+      if(tp_index==0) tp_former = tp;
+      tpInfoFile << tp_index << "," << tp.channel << "," << (tp.time_start - minStartTime)  << "," << std::abs(static_cast<int64_t>(tp.time_start) - static_cast<int64_t>(tp_former.time_start)) << std::endl; // static_cast<double> used to prevent uncompatible negative timestamp
+      tp_former = tp;
+      tp_index++;
+    }
+
+    tpInfoFile.close();
+  } else {
+    std::cerr << "Unable to open the longest track TP info file." << std::endl;
+  }
+}
+
+void
+TriggerActivityMakerChannelTimeAdjacency::dump_longest_track_record_time_ordered()
+{
+  // Output the TP info of the longest track to a file ordered by time, not by channel
+  std::ofstream tpInfoFileTimeOrdered("tp_info_longest_track_time_ordered_time_filtered.txt", std::ios::app);
+  if (tpInfoFileTimeOrdered.is_open()) {
+    if (m_fragment_count == 0) {
+      tpInfoFileTimeOrdered << "Longest Track TP Information" << std::endl;
+      tpInfoFileTimeOrdered << "TP index, Channel, Relative Start Time (ticks), Relative Time Difference (ticks)" << std::endl;
+    }
+    
+    tpInfoFileTimeOrdered << "Fragment number: " << m_fragment_count << std::endl;
+
+    // Calculate the minimum start time
+    timestamp_t minStartTime = std::numeric_limits<timestamp_t>::max();
+    if (!m_longest_track_window.inputs.empty()) {
+      minStartTime = std::min_element(m_longest_track_window.inputs.begin(), m_longest_track_window.inputs.end(),
+        [](const auto& tp1, const auto& tp2) {
+          return tp1.time_start < tp2.time_start;
+        })->time_start;
+    }
+
+    // Generate a Time ordered list of hit channels for this window: m_longest_track_window
+    std::sort(m_longest_track_window.inputs.begin(), m_longest_track_window.inputs.end(), [](const TriggerPrimitive& tp1, const TriggerPrimitive& tp2) {
+      return tp1.time_start < tp2.time_start;
+    });
+
+    int tp_index = 0;
+    TriggerPrimitive tp_former;
+    for (const auto& tp : m_longest_track_window.inputs) {
+      if(tp_index==0) tp_former = tp;
+      tpInfoFileTimeOrdered << tp_index << "," << tp.channel << "," << (tp.time_start - minStartTime)  << "," << std::abs(static_cast<int64_t>(tp.time_start) - static_cast<int64_t>(tp_former.time_start)) << std::endl; // static_cast<double> used to prevent uncompatible negative timestamp
+      tp_former = tp;
+      tp_index++;
+    }
+
+    tpInfoFileTimeOrdered.close();
+  } else {
+    std::cerr << "Unable to open the longest track TP info file." << std::endl;
+  }
+}
+
+// Register algo in TA Factory
+REGISTER_TRIGGER_ACTIVITY_MAKER(TRACE_NAME, TriggerActivityMakerChannelTimeAdjacency)

--- a/src/TriggerCandidateMakerChannelTimeAdjacency.cpp
+++ b/src/TriggerCandidateMakerChannelTimeAdjacency.cpp
@@ -1,0 +1,148 @@
+/**
+ * @file TriggerCandidateMakerChannelTimeAdjacency.cpp
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2021.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#include "triggeralgs/ChannelTimeAdjacency/TriggerCandidateMakerChannelTimeAdjacency.hpp"
+#include "triggeralgs/Logging.hpp"
+
+#include "TRACE/trace.h"
+#define TRACE_NAME "TriggerCandidateMakerChannelTimeAdjacencyPlugin"
+
+#include <vector>
+#include <math.h>
+
+using namespace triggeralgs;
+
+using Logging::TLVL_DEBUG_ALL;
+using Logging::TLVL_DEBUG_HIGH;
+using Logging::TLVL_DEBUG_MEDIUM;
+using Logging::TLVL_VERY_IMPORTANT;
+
+void
+TriggerCandidateMakerChannelTimeAdjacency::operator()(const TriggerActivity& activity,
+                                                std::vector<TriggerCandidate>& output_tc)
+{
+
+  // Find the offset for the very first data vs system time measure:
+  if (m_activity_count == 0) {
+    using namespace std::chrono;
+    m_initial_offset = duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count() - activity.time_start*16*1e-6; 
+  }
+
+  // The first time operator is called, reset window object.
+  if (m_current_window.is_empty()) {
+    m_current_window.reset(activity);
+    m_activity_count++;
+  }
+
+  // If the difference between the current TA's start time and the start of the window
+  // is less than the specified window size, add the TA to the window.
+  else if ((activity.time_start - m_current_window.time_start) < m_window_length) {
+    TLOG_DEBUG(TLVL_DEBUG_HIGH) << "[TCM:CA] Window not yet complete, adding the activity to the window.";
+    m_current_window.add(activity);
+  }
+  // If it is not, move the window along.
+  else {
+    TLOG_DEBUG(TLVL_DEBUG_ALL) << "[TCM:CA] TAWindow is at required length but specified threshold not met, shifting window along.";
+    m_current_window.move(activity, m_window_length);
+  }
+
+
+  // If the addition of the current TA to the window would make it longer
+  // than the specified window length, don't add it but check whether the sum of all adc in
+  // the existing window is above the specified threshold. If it is, and we are triggering on ADC,
+  // make a TA and start a fresh window with the current TP.
+  if (m_current_window.adc_integral > m_adc_threshold && m_trigger_on_adc) {
+    TLOG_DEBUG(TLVL_DEBUG_MEDIUM) << "[TCM:CA] m_current_window.adc_integral " << m_current_window.adc_integral << " - m_adc_threshold " << m_adc_threshold;
+    m_tc_number++;
+    TriggerCandidate tc = construct_tc();
+    TLOG_DEBUG(TLVL_DEBUG_MEDIUM) << "[TCM:CA] tc.time_start=" << tc.time_start << " tc.time_end=" << tc.time_end << " len(tc.inputs) " << tc.inputs.size();
+    for( const auto& ta : tc.inputs ) {
+      TLOG_DEBUG(TLVL_DEBUG_ALL) << "[TCM:CA] [TA] ta.time_start=" << ta.time_start << " ta.time_end=" << ta.time_end << " ta.adc_integral=" << ta.adc_integral;
+    }
+
+    output_tc.push_back(tc);
+    m_current_window.clear();
+  }
+
+  // If the addition of the current TA to the window would make it longer
+  // than the specified window length, don't add it but check whether the number of hit channels in
+  // the existing window is above the specified threshold. If it is, and we are triggering on channels,
+  // make a TC and start a fresh window with the current TA.
+  else if (m_current_window.n_channels_hit() > m_n_channels_threshold && m_trigger_on_n_channels) {
+    m_tc_number++;
+    output_tc.push_back(construct_tc());
+    m_current_window.clear();
+  }
+  
+  m_activity_count++;
+  return;
+}
+
+
+void
+TriggerCandidateMakerChannelTimeAdjacency::configure(const nlohmann::json& config)
+{
+  if (config.is_object()) {
+    if (config.contains("trigger_on_adc"))
+      m_trigger_on_adc = config["trigger_on_adc"];
+    if (config.contains("trigger_on_n_channels"))
+      m_trigger_on_n_channels = config["trigger_on_n_channels"];
+    if (config.contains("adc_threshold"))
+      m_adc_threshold = config["adc_threshold"];
+    if (config.contains("n_channels_threshold"))
+      m_n_channels_threshold = config["n_channels_threshold"];
+    if (config.contains("window_length"))
+      m_window_length = config["window_length"];
+    if (config.contains("readout_window_ticks_before"))
+      m_readout_window_ticks_before = config["readout_window_ticks_before"];
+    if (config.contains("readout_window_ticks_after"))
+      m_readout_window_ticks_after = config["readout_window_ticks_after"];
+  }
+
+  // Both trigger flags were false. This will never trigger.
+  if (!m_trigger_on_adc && !m_trigger_on_n_channels) {
+    TLOG_DEBUG(TLVL_VERY_IMPORTANT) << "[TCM:CA] Not triggering! All trigger flags are false!";
+    throw BadConfiguration(ERS_HERE, TRACE_NAME);
+  }
+
+  return;
+}
+
+TriggerCandidate
+TriggerCandidateMakerChannelTimeAdjacency::construct_tc() const
+{
+  TriggerActivity latest_ta_in_window = m_current_window.inputs.back();
+
+  TriggerCandidate tc;
+  tc.time_start = m_current_window.time_start - m_readout_window_ticks_before;
+  tc.time_end = m_current_window.time_start + m_readout_window_ticks_after;
+  //tc.time_end = latest_ta_in_window.inputs.back().time_start + latest_ta_in_window.inputs.back().time_over_threshold;
+  tc.time_candidate = m_current_window.time_start;
+  tc.detid = latest_ta_in_window.detid;
+  tc.type = TriggerCandidate::Type::kChannelTimeAdjacency;
+  tc.algorithm = TriggerCandidate::Algorithm::kChannelTimeAdjacency;
+
+  // Take the list of triggeralgs::TriggerActivity in the current
+  // window and convert them (implicitly) to detdataformats'
+  // TriggerActivityData, which is the base class of TriggerActivity
+  for (auto& ta : m_current_window.inputs) {
+    tc.inputs.push_back(ta);
+  }
+
+  return tc;
+}
+
+// Functions below this line are for debugging purposes.
+void
+TriggerCandidateMakerChannelTimeAdjacency::add_window_to_record(TAWindow window)
+{
+  m_window_record.push_back(window);
+  return;
+}
+
+REGISTER_TRIGGER_CANDIDATE_MAKER(TRACE_NAME, TriggerCandidateMakerChannelTimeAdjacency)


### PR DESCRIPTION

# ChannelTimeAdjacency Algorithm

The ChannelTimeAdjacency algorithm is an enhanced version of the adjacency algorithm implemented for the HorizontalMuon algorithm, specifically focusing on the TA maker part.

## Overview

The algorithm constructs Trigger Activities (TAs) by analyzing Trigger Primitives (TPs) within a given time window. TAs are formed by grouping TPs that represent an activity or track, excluding background/outliers. The longest track is stored in the time window.

## Key Features

- Improved version of the adjacency logic present at the HorizontalMuon algorithm.
- Constructs TAs based on TPs within a TP window that have a channel-time correlation.
- Excludes background/outliers from TAs.

## References

- [Adjacency trigger refinement by Hamza Amar Es-sghir (IFIC-Valencia, Spain)](https://indico.fnal.gov/event/64229/)