### PR TITLE
Allowing ADCSimpleWindow user-provided tc-type output

### DIFF
--- a/include/triggeralgs/ADCSimpleWindow/TriggerCandidateMakerADCSimpleWindow.hpp
+++ b/include/triggeralgs/ADCSimpleWindow/TriggerCandidateMakerADCSimpleWindow.hpp
@@ -26,7 +26,9 @@ public:
 private:
 
   uint64_t m_activity_count = 0; // NOLINT(build/unsigned)
-  
+
+  /// @brief Configurable TC type to produce by this TC algorithm
+  TriggerCandidate::Type m_tc_type = TriggerCandidate::Type::kADCSimpleWindow;
 };
 
 } // namespace triggeralgs

--- a/src/TriggerCandidateMakerADCSimpleWindow.cpp
+++ b/src/TriggerCandidateMakerADCSimpleWindow.cpp
@@ -26,13 +26,16 @@ TriggerCandidateMakerADCSimpleWindow::operator()(const TriggerActivity& activity
   m_activity_count++;
   std::vector<TriggerActivity::TriggerActivityData> ta_list = {static_cast<TriggerActivity::TriggerActivityData>(activity)};
 
-  TLOG_DEBUG(TLVL_DEBUG_LOW) << "[TCM:ADCSW] Emitting an ADCSimpleWindow TriggerCandidate " << (m_activity_count-1);
+  TLOG_DEBUG(TLVL_DEBUG_LOW) << "[TCM:ADCSW] Emitting an "
+                             << dunedaq::trgdataformats::get_trigger_candidate_type_names()[m_tc_type]
+                             << " TriggerCandidate with ADCSimpleWindow algorithm" << (m_activity_count-1);
+
   TriggerCandidate tc;
   tc.time_start = activity.time_start; 
   tc.time_end = activity.time_end;  
   tc.time_candidate = activity.time_activity;
   tc.detid = activity.detid;
-  tc.type = TriggerCandidate::Type::kADCSimpleWindow;
+  tc.type = m_tc_type;
   tc.algorithm = TriggerCandidate::Algorithm::kADCSimpleWindow;
 
   tc.inputs = ta_list;
@@ -44,6 +47,23 @@ TriggerCandidateMakerADCSimpleWindow::operator()(const TriggerActivity& activity
 void
 TriggerCandidateMakerADCSimpleWindow::configure(const nlohmann::json &config)
 {
+  // Don't configure if no configuration object
+  if (!config.is_object())
+    return;
+
+  // Set the TC name
+  if (config.contains("tc_type_name")){
+    m_tc_type = static_cast<triggeralgs::TriggerCandidate::Type>(
+         dunedaq::trgdataformats::string_to_fragment_type_value(config["tc_type_name"]));
+
+    // Set unknown to the default kADCSimpleWindow
+    if (m_tc_type == triggeralgs::TriggerCandidate::Type::kUnknown) {
+      m_tc_type = TriggerCandidate::Type::kADCSimpleWindow;
+    }
+
+    TLOG() << "[TCM:ADCSW]: setting output TC type to "
+           << dunedaq::trgdataformats::get_trigger_candidate_type_names()[m_tc_type];
+  }
 }
 
 REGISTER_TRIGGER_CANDIDATE_MAKER(TRACE_NAME, TriggerCandidateMakerADCSimpleWindow)


### PR DESCRIPTION
This PR allows the `ADCSimpleWindow` to produce TC with any user-provided TC-type, something that in v5 we will probably want all algorithms to be capable of. We could use `ADCSimpleWindow` algorithm to make both `lowE` and `highE` TC-types, or perhaps one tc-type targeting ground-shakes and another targeting highE.

This PR goes together with https://github.com/DUNE-DAQ/daqconf/pull/493, which also fixes bug when making config for multiple  concurrent TA algorithms (per subdetector).

**The default behaviour and required configurations are not changed.**

**Tested by:**
1. `3ru_3df_multirun_test.py` passes tests.
2. Running with the replay application, both in default one-algorithm-unchanged mode, and with multiple `ADCSimpleWindow` configured in different ways with one outputting `kADCSimpleWindow` tc-type, and the other outputting `kSupernova`. Output data files look as expected. Grafana graph attached below.
![grafana_test](https://github.com/user-attachments/assets/5ab7bffb-ccf7-4806-836a-ebea7effae48)

