### PR TITLE
Correct TAM ADCSimpleWindow Trace Name

### DIFF
--- a/src/TAMakerADCSimpleWindowAlgorithm.cpp
+++ b/src/TAMakerADCSimpleWindowAlgorithm.cpp
@@ -9,7 +9,7 @@
 #include "triggeralgs/ADCSimpleWindow/TAMakerADCSimpleWindowAlgorithm.hpp"
 
 #include "TRACE/trace.h"
-#define TRACE_NAME "TAMakerADCSimpleWindowAlgorithmPlugin"
+#define TRACE_NAME "TAMakerADCSimpleWindowAlgorithm"
 
 #include <vector>
 


### PR DESCRIPTION
The naming for this algorithm was incorrect given the format and thus not findable by the TAM factory.

Testing was done using the `trgtools_process_tpstream` within https://github.com/DUNE-DAQ/trgtools/pull/48 and modifying the example configuration to use the ADC Simple Window TAM and TCM.