### PR TITLE
Configurable TC type output for all the algorithms

### DIFF
--- a/include/triggeralgs/Issues.hpp
+++ b/include/triggeralgs/Issues.hpp
@@ -30,7 +30,7 @@ ERS_DECLARE_ISSUE(triggeralgs,
 
 ERS_DECLARE_ISSUE(triggeralgs,
                   InvalidConfiguration,
-                  "Invalid configuration error:" << conferror,
+                  "Invalid configuration error: " << conferror,
                   ((std::string)conferror))
 
 

--- a/include/triggeralgs/Issues.hpp
+++ b/include/triggeralgs/Issues.hpp
@@ -28,4 +28,10 @@ ERS_DECLARE_ISSUE(triggeralgs,
                   "Bad configuration in " << alg_name,
                   ((std::string)alg_name))
 
+ERS_DECLARE_ISSUE(triggeralgs,
+                  InvalidConfiguration,
+                  "Invalid configuration error:" << conferror,
+                  ((std::string)conferror))
+
+
 #endif // TRIGGERALGS_INCLUDE_TRIGGERALGS_ISSUES_HPP_

--- a/include/triggeralgs/TriggerCandidateMaker.hpp
+++ b/include/triggeralgs/TriggerCandidateMaker.hpp
@@ -105,10 +105,22 @@ public:
       return;
     }
 
-    if (config.contains("prescale"))
+    if (config.contains("prescale")) {
       m_prescale = config["prescale"];
+    }
 
-    TLOG() << "[TCM]: prescale  : " << m_prescale;
+    if (config.contains("tc_type_name")) {
+      m_tc_type_out = static_cast<TriggerCandidate::Type>(
+          dunedaq::trgdataformats::string_to_fragment_type_value(config["tc_type_name"]));
+    }
+
+    if (m_tc_type_out == TriggerCandidate::Type::kUnknown) {
+      throw(InvalidConfiguration(ERS_HERE, "Provided an unknown output TC type: "
+              + std::string(config["tc_type_name"])));
+    }
+
+    TLOG() << "[TCM]: prescale   : " << m_prescale;
+    TLOG() << "[TCM]: TC type out: " << config["tc_type_name"];
   }
 
   std::atomic<uint64_t> m_data_vs_system_time = 0;
@@ -118,6 +130,10 @@ public:
   uint64_t m_prescale = 1;
   /// @brief TC made count for prescaling
   uint64_t m_tc_count = 0;
+
+  /// @brief Configurable TC type output
+  TriggerCandidate::Type m_tc_type_out = TriggerCandidate::Type::kUnknown;
+
 };
 
 } // namespace triggeralgs

--- a/src/TCMakerADCSimpleWindowAlgorithm.cpp
+++ b/src/TCMakerADCSimpleWindowAlgorithm.cpp
@@ -27,7 +27,7 @@ TCMakerADCSimpleWindowAlgorithm::process(const TriggerActivity& activity, std::v
   tc.time_end = activity.time_end;  
   tc.time_candidate = activity.time_activity;
   tc.detid = activity.detid;
-  tc.type = TriggerCandidate::Type::kADCSimpleWindow;
+  tc.type = m_tc_type_out; 
   tc.algorithm = TriggerCandidate::Algorithm::kADCSimpleWindow;
 
   tc.inputs = ta_list;

--- a/src/TCMakerBundleNAlgorithm.cpp
+++ b/src/TCMakerBundleNAlgorithm.cpp
@@ -24,7 +24,7 @@ void TCMakerBundleNAlgorithm::set_tc_attributes() {
     m_current_tc.time_end = m_current_tc.inputs.back().time_end;
     m_current_tc.time_candidate = front_ta.time_start; // TODO: Conforming. Do we change this?
     m_current_tc.detid = front_ta.detid;
-    m_current_tc.type = TriggerCandidate::Type::kBundle;
+    m_current_tc.type = m_tc_type_out;
     m_current_tc.algorithm = TriggerCandidate::Algorithm::kBundle;
     return;
 }

--- a/src/TCMakerChannelAdjacencyAlgorithm.cpp
+++ b/src/TCMakerChannelAdjacencyAlgorithm.cpp
@@ -116,7 +116,7 @@ TCMakerChannelAdjacencyAlgorithm::construct_tc() const
   tc.time_end = latest_ta_in_window.inputs.back().time_start;
   tc.time_candidate = m_current_window.time_start;
   tc.detid = latest_ta_in_window.detid;
-  tc.type = TriggerCandidate::Type::kChannelAdjacency;
+  tc.type = m_tc_type_out;
   tc.algorithm = TriggerCandidate::Algorithm::kChannelAdjacency;
 
   // Take the list of triggeralgs::TriggerActivity in the current

--- a/src/TCMakerChannelDistanceAlgorithm.cpp
+++ b/src/TCMakerChannelDistanceAlgorithm.cpp
@@ -44,7 +44,7 @@ TCMakerChannelDistanceAlgorithm::set_tc_attributes()
 
   m_current_tc.detid = first_ta.detid;
   m_current_tc.algorithm = TriggerCandidate::Algorithm::kChannelDistance;
-  m_current_tc.type = TriggerCandidate::Type::kChannelDistance;
+  m_current_tc.type = m_tc_type_out;
   return;
 }
 

--- a/src/TCMakerDBSCANAlgorithm.cpp
+++ b/src/TCMakerDBSCANAlgorithm.cpp
@@ -44,7 +44,7 @@ TCMakerDBSCANAlgorithm::set_tc_attributes()
 
   m_current_tc.detid = first_ta.detid;
   m_current_tc.algorithm = TriggerCandidate::Algorithm::kDBSCAN;
-  m_current_tc.type = TriggerCandidate::Type::kDBSCAN;
+  m_current_tc.type = m_tc_type_out;
   return;
 }
 

--- a/src/TCMakerHorizontalMuonAlgorithm.cpp
+++ b/src/TCMakerHorizontalMuonAlgorithm.cpp
@@ -138,7 +138,7 @@ TCMakerHorizontalMuonAlgorithm::construct_tc() const
   tc.time_end = latest_ta_in_window.inputs.back().time_start;
   tc.time_candidate = m_current_window.time_start;
   tc.detid = latest_ta_in_window.detid;
-  tc.type = TriggerCandidate::Type::kHorizontalMuon;
+  tc.type = m_tc_type_out;
   tc.algorithm = TriggerCandidate::Algorithm::kHorizontalMuon;
 
   // Take the list of triggeralgs::TriggerActivity in the current

--- a/src/TCMakerMichelElectronAlgorithm.cpp
+++ b/src/TCMakerMichelElectronAlgorithm.cpp
@@ -138,7 +138,7 @@ TCMakerMichelElectronAlgorithm::construct_tc() const
     latest_ta_in_window.inputs.back().time_start + latest_ta_in_window.inputs.back().time_over_threshold;
   tc.time_candidate = m_current_window.time_start;
   tc.detid = latest_ta_in_window.detid;
-  tc.type = TriggerCandidate::Type::kMichelElectron;
+  tc.type = m_tc_type_out; 
   tc.algorithm = TriggerCandidate::Algorithm::kMichelElectron;
 
   // Take the list of triggeralgs::TriggerActivity in the current

--- a/src/TCMakerPlaneCoincidenceAlgorithm.cpp
+++ b/src/TCMakerPlaneCoincidenceAlgorithm.cpp
@@ -131,7 +131,7 @@ TCMakerPlaneCoincidenceAlgorithm::construct_tc() const
     latest_ta_in_window.inputs.back().time_start + latest_ta_in_window.inputs.back().time_over_threshold;
   tc.time_candidate = m_current_window.time_start;
   tc.detid = latest_ta_in_window.detid;
-  tc.type = TriggerCandidate::Type::kPlaneCoincidence;
+  tc.type = m_tc_type_out;
   tc.algorithm = TriggerCandidate::Algorithm::kPlaneCoincidence;
 
   // Take the list of triggeralgs::TriggerActivity in the current

--- a/src/TCMakerPrescaleAlgorithm.cpp
+++ b/src/TCMakerPrescaleAlgorithm.cpp
@@ -26,7 +26,7 @@ TCMakerPrescaleAlgorithm::process(const TriggerActivity& activity, std::vector<T
   tc.time_end = activity.time_end;
   tc.time_candidate = activity.time_start;
   tc.detid = activity.detid;
-  tc.type = TriggerCandidate::Type::kPrescale;
+  tc.type = m_tc_type_out;
   tc.algorithm = TriggerCandidate::Algorithm::kPrescale;
 
   tc.inputs = ta_list;

--- a/src/TCMakerSupernovaAlgorithm.cpp
+++ b/src/TCMakerSupernovaAlgorithm.cpp
@@ -31,7 +31,7 @@ TCMakerSupernovaAlgorithm::process(const TriggerActivity& activity, std::vector<
     tc.time_end = activity.time_end;  // time_end; but that should probably be _at least_ this number
     tc.time_candidate = time;
     tc.detid = detid;
-    tc.type = TriggerCandidate::Type::kSupernova; // type ( flag that says what type of trigger might be (e.g. SN/Muon/Beam) )
+    tc.type = m_tc_type_out; // type ( flag that says what type of trigger might be (e.g. SN/Muon/Beam) )
     tc.algorithm = TriggerCandidate::Algorithm::kSupernova; // algorithm ( flag that says which algorithm created the trigger (e.g. SN/HE/Solar) )
     tc.inputs =  m_activity;
 


### PR DESCRIPTION
This PR has to go together with:
1. https://github.com/DUNE-DAQ/appmodel/pull/152
2. https://github.com/DUNE-DAQ/daqsystemtest/pull/147

The TC type output is now decoupled from the TC algorithm: user can attach any TC type to any algorithm being used.
E.g. if using `kADCSimpleWindow` TAMaker, but `kPrescale` TC-maker, we can set the TC-maker to output `kADCSimpleWindow` TC-output. User can also now run two the same algorithms, with different configurations, outputting two different TC-types (it was already possible for ADCSimpleWindow algorithm in v4, but now is possible for all the algorithms).

In the future, we will likely have TC-types like "HighE", "LowE", "kSupernova", rather than algorithm-based TC-type names, and this PR is the first step towards that.

Tested by:
1. Running with the TC-types currently implemented in the test configuration (so kPrescale outputting kPrescale).
2. Running with TC-type that doesn't match the algorithm (Prescale algorithm outputting kSupernova).
3. Giving incorrect TC-type name to see if trigger crashes gracefully with useful logging (Prescale trying to output "kSupernovae"

In the first two cases the HDF5 output matched the expectation, in the tc-maker thrown an exception with message:
```
2024-Nov-01 17:32:35,685 ERROR [virtual void triggeralgs::TriggerCandidateMaker::configure(const nlohmann::json&) at /nfs/home/asztuc/workspace/releases/rel_fddaq-v5.2.0-rc1-a9/sourcecode/triggeralgs/include/triggeralgs/TriggerCandidateMaker.hpp:118] Invalid configuration error:Provided an unknown output TC type: kSupernovae
```
