### PR TITLE
Updated uses of the string_to_fragment_type_value() method to use its…

### DIFF
--- a/include/triggeralgs/TriggerCandidateMaker.hpp
+++ b/include/triggeralgs/TriggerCandidateMaker.hpp
@@ -111,7 +111,7 @@ public:
 
     if (config.contains("tc_type_name")) {
       m_tc_type_out = static_cast<TriggerCandidate::Type>(
-          dunedaq::trgdataformats::string_to_fragment_type_value(config["tc_type_name"]));
+          dunedaq::trgdataformats::string_to_trigger_candidate_type(config["tc_type_name"]));
     }
 
     if (m_tc_type_out == TriggerCandidate::Type::kUnknown) {


### PR DESCRIPTION
… new name, string_to_trigger_candidate_type(), which seems much more appropriate.

These changes need to be tested and merged along with ones in the [trgdataformats](https://github.com/DUNE-DAQ/trgdataformats/pull/47) and [trigger](https://github.com/DUNE-DAQ/trigger/pull/366) repos.