### PR TITLE
Added the TA start, end, and activity times to the 'Emitting TA' debug statement…

### DIFF
--- a/include/triggeralgs/TriggerActivityMaker.hpp
+++ b/include/triggeralgs/TriggerActivityMaker.hpp
@@ -99,7 +99,9 @@ public:
           continue;
         }
 
-        TLOG(TLVL_DEBUG_10) << "Emitting prescaled TriggerActivity " << (m_ta_count-1);
+        TLOG(TLVL_DEBUG_10) << "Emitting prescaled TriggerActivity " << (m_ta_count-1)
+                            << " with time start/end/activity: " << iter->time_start
+                            << " " << iter->time_end << " " << iter->time_activity;
         ++iter;
       }
     }


### PR DESCRIPTION
…in TriggerActivityMaker.

I found this additional information very useful when trying to understand the correlations between prescaled TAs from different sources, so it seems reasonable to make it a standard part of the code.

To test this change:

- create a software area based on a recently nightly build (e.g. [here](https://github.com/DUNE-DAQ/daqconf/wiki/Setting-up-a-fddaq%E2%80%90v5.3.0-development-area))
- add the `triggeralgs` repo to that software area and check out the `kbiery/tam_debug_additional_info` branch in that repo; rebuild the software
- `export TRACE_FILE=$DBT_AREA_ROOT/log/${USER}_dunedaq.trace`
- `tonM -n TriggerActivityMaker.hpp DEBUG+10`
- `pytest -s -k TPG -p no:cacheprovider ${DAQSYSTEMTEST_SHARE}/integtest/readout_type_scan.py`
- `tshow | tdelta -ct 1 | grep Emitting | head`
