### PR TITLE
Zeroing out stateful values in TA/TP Window upon their initialization.

### DIFF
--- a/include/triggeralgs/TAWindow.hpp
+++ b/include/triggeralgs/TAWindow.hpp
@@ -49,8 +49,8 @@ public:
 
   friend std::ostream& operator<<(std::ostream& os, const TAWindow& window);
 
-  timestamp_t time_start;
-  uint64_t adc_integral;
+  timestamp_t time_start = 0;
+  uint64_t adc_integral = 0;
   std::unordered_map<channel_t, uint16_t> channel_states;
   std::vector<TriggerActivity> inputs;
 };

--- a/include/triggeralgs/TPWindow.hpp
+++ b/include/triggeralgs/TPWindow.hpp
@@ -34,8 +34,8 @@ public:
 
   friend std::ostream& operator<<(std::ostream& os, const TPWindow& window);
 
-  timestamp_t time_start;
-  uint32_t adc_integral;
+  timestamp_t time_start = 0;
+  uint32_t adc_integral = 0;
   std::unordered_map<channel_t, uint16_t> channel_states;
   std::vector<TriggerPrimitive> inputs;
 };


### PR DESCRIPTION
Currently, TAMs/TCMs rely on calling the `clear()` method in the Window classes in order to prepare a zero state for the windows. This should be done by default when a new window is created, so that the `clear` does not need to be called upon initialization.

Current implementation causes issues at least for the Adjacency TAM, where windows are spawned in the middle of a run and never cleared before use. 