### PR TITLE
Set the TA pars correctly by TAMakerADCSimpleWindow

### DIFF
--- a/src/TAMakerADCSimpleWindowAlgorithm.cpp
+++ b/src/TAMakerADCSimpleWindowAlgorithm.cpp
@@ -88,8 +88,8 @@ TAMakerADCSimpleWindowAlgorithm::construct_ta() const
   // The time_peak, time_activity, channel_* and adc_peak fields of this TA are irrelevent
   // for the purpose of this trigger alg.
   TriggerActivity ta;
-  ta.time_start = m_current_window.time_start;
-  ta.time_end = latest_tp_in_window.time_start + latest_tp_in_window.time_over_threshold;
+  ta.time_start = latest_tp_in_window.time_start;
+  ta.time_end = latest_tp_in_window.time_start;
   ta.time_peak = latest_tp_in_window.time_peak;
   ta.time_activity = latest_tp_in_window.time_peak;
   ta.channel_start = latest_tp_in_window.channel;
@@ -101,6 +101,19 @@ TAMakerADCSimpleWindowAlgorithm::construct_ta() const
   ta.type = TriggerActivity::Type::kTPC;
   ta.algorithm = TriggerActivity::Algorithm::kADCSimpleWindow;
   ta.inputs = m_current_window.tp_list;
+
+  for (const auto& tp : ta.inputs) {
+    ta.time_start = std::min(ta.time_start, tp.time_start);
+    ta.time_end = std::max(ta.time_end, tp.time_start);
+    ta.channel_start = std::min(ta.channel_start, tp.channel);
+    ta.channel_end = std::max(ta.channel_end, tp.channel);
+    if (tp.adc_peak > ta.adc_peak) {
+      ta.time_peak = tp.time_peak;
+      ta.adc_peak = tp.adc_peak;
+      ta.channel_peak = tp.channel;
+    }
+  }
+
   return ta;
 }
 


### PR DESCRIPTION
`TAMakerADCSimpleWindow` did not set TA parameter correctly: so e.g. the `channel_start` and `channel_end` were the same, based off the very last TP in the window.

This PR correct this.

Tested by running drunc offline with `ADCSimpleWindow` with small readout windows, as well as by running emulation on the PD2 data to find some examples of ground shakes -- large ADC, window of 150 ticks, and looking at the hdf5 output. Example plot below.

![output_page9](https://github.com/user-attachments/assets/1942da64-7efe-4909-9f20-68990d8d1237)
Trigger candidate generated using emulation on PD2HD TPStream, with Trigger Activities generated using the `ADCSimpleWindow` algorithm in red boxes (and black dots representing individual TPs), with TA ADC threshold of 10M, and max window size of 150 ticks each. Red windows extracted from the TA objects.
