### PR TITLE
Include logging/Logging.hpp whenever ERS issues are declared, includi…

### DIFF
--- a/include/triggeralgs/Issues.hpp
+++ b/include/triggeralgs/Issues.hpp
@@ -10,7 +10,7 @@
 #define TRIGGERALGS_INCLUDE_TRIGGERALGS_ISSUES_HPP_
 
 #include "ers/Issue.hpp"
-#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
+#include "logging/Logging.hpp" // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 
 #include <string>
 

--- a/include/triggeralgs/Issues.hpp
+++ b/include/triggeralgs/Issues.hpp
@@ -10,6 +10,7 @@
 #define TRIGGERALGS_INCLUDE_TRIGGERALGS_ISSUES_HPP_
 
 #include "ers/Issue.hpp"
+#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 
 #include <string>
 


### PR DESCRIPTION
…ng note on why (TLOG() << ERSIssue only works when Logging.hpp included first)