### PR TITLE
Avoid a crash in TriggerCandidateMaker when a configuration parameter is missing

### DIFF
--- a/include/triggeralgs/TriggerCandidateMaker.hpp
+++ b/include/triggeralgs/TriggerCandidateMaker.hpp
@@ -115,6 +115,8 @@ public:
     }
 
     if (m_tc_type_out == TriggerCandidate::Type::kUnknown) {
+      // 27-Feb-2025, KAB: moified the following statement to check whether the configuration
+      // contains the tc_type_name parameter before trying to add it do the exception message.
       throw(InvalidConfiguration(ERS_HERE, "Provided an unknown output TC type: " +
                                  (config.contains("tc_type_name") ?
                                   std::string(config["tc_type_name"]) : "null")));

--- a/include/triggeralgs/TriggerCandidateMaker.hpp
+++ b/include/triggeralgs/TriggerCandidateMaker.hpp
@@ -115,8 +115,9 @@ public:
     }
 
     if (m_tc_type_out == TriggerCandidate::Type::kUnknown) {
-      throw(InvalidConfiguration(ERS_HERE, "Provided an unknown output TC type: "
-              + std::string(config["tc_type_name"])));
+      throw(InvalidConfiguration(ERS_HERE, "Provided an unknown output TC type: " +
+                                 (config.contains("tc_type_name") ?
+                                  std::string(config["tc_type_name"]) : "null")));
     }
 
     TLOG() << "[TCM]: prescale   : " << m_prescale;


### PR DESCRIPTION
Background:  when the v5.2.1 software changes were merged to `develop` branches, a line in `appmodel/schema/appmodel/trigger.schema.xml` accidentally went missing (see [here](https://github.com/DUNE-DAQ/appmodel/pull/170)).  This caused the `tc-maker-1` process to start crashing.  The reason for the crash was that a statement in the TriggerCandidateMaker code was assuming that the config parameter in question was available when it created an ERS exception as part of reporting the error.

This change avoids the crash.  Of course, the `tc-maker-1` process will still terminate earlier than expected if the config parameter ever goes missing again.  But, with this change and recent fixes in `drunc` and `appfwk`, we will be able to tell what happened from the `tc-maker-1` log file.

If there is a better string than "null" to indicate that the `tc_type_name` parameter is missing, that would be great by me.
