### PR TITLE
Switched the TLOG() call to a TLOG_DEBUG() call for the 'Emitting pre…

### DIFF
--- a/include/triggeralgs/TriggerActivityMaker.hpp
+++ b/include/triggeralgs/TriggerActivityMaker.hpp
@@ -99,9 +99,9 @@ public:
           continue;
         }
 
-        TLOG(TLVL_DEBUG_10) << "Emitting prescaled TriggerActivity " << (m_ta_count-1)
-                            << " with time start/end/activity: " << iter->time_start
-                            << " " << iter->time_end << " " << iter->time_activity;
+        TLOG_DEBUG(TLVL_DEBUG_MEDIUM) << "Emitting prescaled TriggerActivity " << (m_ta_count-1)
+                                      << " with time start/end/activity: " << iter->time_start
+                                      << " " << iter->time_end << " " << iter->time_activity;
         ++iter;
       }
     }


### PR DESCRIPTION
…scaled TriggerActivity' message to reduce clutter in the logs and TRACE buffer.

My recollection was that we had fixed this already, but I guess not.