### PR TITLE
additional checks for pointer validity

### DIFF
--- a/include/triggeralgs/AbstractFactory.hxx
+++ b/include/triggeralgs/AbstractFactory.hxx
@@ -25,6 +25,14 @@ template <typename T>
 void AbstractFactory<T>::register_creator(const std::string alg_name, maker_creator creator)
 {
   creation_map& makers = get_makers();
+  
+  // Check invalid state in the map
+  for (const auto& pair : makers) {
+    if (!pair.second) {  // nullptr or invalid
+      throw FactoryInvalidState(ERS_HERE, alg_name);
+    }
+  }
+
   auto it = makers.find(alg_name);
 
   if (it == makers.end()) {

--- a/include/triggeralgs/Issues.hpp
+++ b/include/triggeralgs/Issues.hpp
@@ -20,6 +20,11 @@ ERS_DECLARE_ISSUE(triggeralgs,
                   ((std::string)alg_name))
 
 ERS_DECLARE_ISSUE(triggeralgs,
+                  FactoryInvalidState,
+                  "Makers map contains invalid/null pointers " << alg_name,
+                  ((std::string)alg_name))
+
+ERS_DECLARE_ISSUE(triggeralgs,
                   FactoryNotFound,
                   "Factory couldn't find: " << alg_name,
                   ((std::string)alg_name))


### PR DESCRIPTION
This PR adds additional checks for pointers insides a custom map. 

This addresses issue https://github.com/DUNE-DAQ/triggeralgs/issues/94