### PR TITLE
Johnfreeman/merge fddaq v5.3.2 rc2 a9 into develop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.13)
-project(triggeralgs VERSION 1.5.0)
+project(triggeralgs VERSION 1.5.1)
 
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)

--- a/include/triggeralgs/PlaneCoincidence/TAMakerPlaneCoincidenceAlgorithm.hpp
+++ b/include/triggeralgs/PlaneCoincidence/TAMakerPlaneCoincidenceAlgorithm.hpp
@@ -56,7 +56,7 @@ private:
   timestamp_t m_window_length = 3000;    // Shouldn't exceed the max drift
 
   // Channel map object, for separating TPs by the plane view they come from
-  std::shared_ptr<dunedaq::detchannelmaps::TPCChannelMap> channelMap = dunedaq::detchannelmaps::make_map(m_channel_map_name);
+  std::shared_ptr<dunedaq::detchannelmaps::TPCChannelMap> channelMap = dunedaq::detchannelmaps::make_tpc_map(m_channel_map_name);
 
   // For debugging and performance study purposes.
   void add_window_to_record(TPWindow window);

--- a/include/triggeralgs/PlaneCoincidence/TAMakerPlaneCoincidenceAlgorithm.hpp
+++ b/include/triggeralgs/PlaneCoincidence/TAMakerPlaneCoincidenceAlgorithm.hpp
@@ -44,7 +44,7 @@ private:
   TPWindow m_induction2_window; // Y
 
   // Configurable parameters.
-  std::string m_channel_map_name = "VDColdboxChannelMap";  // Default is coldbox
+  std::string m_channel_map_name = "VDColdboxTPCChannelMap";  // Default is coldbox
   uint16_t m_adjacency_threshold = 15;   // Default is 15 wire track for testing
   int m_max_adjacency = 0;               // The maximum adjacency seen so far in any window
   uint32_t m_sot_threshold = 2000;       // Work out good values for this


### PR DESCRIPTION
In light of the second fddaq-v5.3.2 candidate release, fddaq-v5.3.2-rc2-a9, this PR will merge in the changes from the patch/fddaq-v5.3.x branch of this repo (with any conflicts resolved, if needed, on this source branch for this PR
johnfreeman/merge_fddaq-v5.3.2-rc2-a9_into_develop). A test build using this branch is available at NFDT_DEV_250603_A9.

Merging is only to be done by Software Coordination.