### PR TITLE
Add partial copy constructors for TriggerActivity and TriggerCandidate

### DIFF
--- a/include/triggeralgs/TriggerActivity.hpp
+++ b/include/triggeralgs/TriggerActivity.hpp
@@ -18,6 +18,18 @@ namespace triggeralgs {
 
 struct TriggerActivity : public dunedaq::trgdataformats::TriggerActivityData
 {
+  TriggerActivity() = default;
+  TriggerActivity(const TriggerActivity&) = default;
+  TriggerActivity(TriggerActivity&&) = default;
+  TriggerActivity& operator=(const TriggerActivity&) = default;
+  TriggerActivity& operator=(TriggerActivity&&) = default;
+  ~TriggerActivity() = default;
+
+  TriggerActivity(dunedaq::trgdataformats::TriggerActivityData&& data)
+      : dunedaq::trgdataformats::TriggerActivityData(std::move(data)) {}
+  TriggerActivity(const dunedaq::trgdataformats::TriggerActivityData &data)
+      : dunedaq::trgdataformats::TriggerActivityData(data) {}
+
   std::vector<TriggerPrimitive> inputs;
 };
 

--- a/include/triggeralgs/TriggerCandidate.hpp
+++ b/include/triggeralgs/TriggerCandidate.hpp
@@ -18,6 +18,18 @@ namespace triggeralgs {
 
 struct TriggerCandidate : public dunedaq::trgdataformats::TriggerCandidateData
 {
+  TriggerCandidate() = default;
+  TriggerCandidate(const TriggerCandidate&) = default;
+  TriggerCandidate(TriggerCandidate&&) = default;
+  TriggerCandidate& operator=(const TriggerCandidate&) = default;
+  TriggerCandidate& operator=(TriggerCandidate&&) = default;
+  ~TriggerCandidate() = default;
+
+  TriggerCandidate(dunedaq::trgdataformats::TriggerCandidateData&& data)
+      : dunedaq::trgdataformats::TriggerCandidateData(std::move(data)) {}
+  TriggerCandidate(const dunedaq::trgdataformats::TriggerCandidateData &data)
+      : dunedaq::trgdataformats::TriggerCandidateData(data) {}
+
   std::vector<dunedaq::trgdataformats::TriggerActivityData> inputs;
 };
 


### PR DESCRIPTION
These constructors allow `TriggerActivity` and `TriggerCandidate` to be directly created from their corresponding data structs in `trgdataformat`.

Motivation for this is due to the fact that TAs are stored offline as `trgdataformat::TriggerActivityData` objects, yet the TC algorithms expects to see `triggeralgs::TriggerActivity` objects. There's no obvious way to convert between the two classes other than static_cast wizardries that may lead to unsafe memory operations.