### PR TITLE
Correctly populate SimpleADCWindow TA fields

### DIFF
--- a/include/triggeralgs/ADCSimpleWindow/TAMakerADCSimpleWindowAlgorithm.hpp
+++ b/include/triggeralgs/ADCSimpleWindow/TAMakerADCSimpleWindowAlgorithm.hpp
@@ -56,6 +56,10 @@ private:
   // Configurable parameters.
   uint32_t m_adc_threshold = 1200000;
   timestamp_t m_window_length = 100000;
+
+  // FIXME: should this be centrally defined?
+  // FIXME 2: assumes the same conversion for all TPC types,  which is not the case (TPCE/BDE = 32, TDE=32.5)
+  const k_sample_to_dts_ticks = 32; 
 };
 
 

--- a/include/triggeralgs/ADCSimpleWindow/TAMakerADCSimpleWindowAlgorithm.hpp
+++ b/include/triggeralgs/ADCSimpleWindow/TAMakerADCSimpleWindowAlgorithm.hpp
@@ -12,7 +12,7 @@
 #include "triggeralgs/TriggerActivityFactory.hpp"
 #include "triggeralgs/Types.hpp"
 
-#include <vector>
+#include <deque>
 
 namespace triggeralgs {
 class TAMakerADCSimpleWindowAlgorithm : public TriggerActivityMaker
@@ -83,7 +83,7 @@ private:
 
       timestamp_t time_start;
       uint32_t adc_integral;
-      std::vector<TriggerPrimitive> tp_list;
+      std::deque<TriggerPrimitive> tp_list;
   };
 
   TriggerActivity construct_ta() const;

--- a/include/triggeralgs/ADCSimpleWindow/TAMakerADCSimpleWindowAlgorithm.hpp
+++ b/include/triggeralgs/ADCSimpleWindow/TAMakerADCSimpleWindowAlgorithm.hpp
@@ -59,7 +59,7 @@ private:
 
   // FIXME: should this be centrally defined?
   // FIXME 2: assumes the same conversion for all TPC types,  which is not the case (TPCE/BDE = 32, TDE=32.5)
-  const k_sample_to_dts_ticks = 32; 
+  const uint16_t k_sample_to_dts_ticks = 32; 
 };
 
 

--- a/include/triggeralgs/ADCSimpleWindow/TAMakerADCSimpleWindowAlgorithm.hpp
+++ b/include/triggeralgs/ADCSimpleWindow/TAMakerADCSimpleWindowAlgorithm.hpp
@@ -23,68 +23,30 @@ public:
   
   void configure(const nlohmann::json &config);
 
-private:  
   class Window {
     public:
+      friend std::ostream& operator<<(std::ostream& os, const Window& window);
+
       bool is_empty() const{
         return tp_list.empty();
       };
-      void add(TriggerPrimitive const &input_tp){
-        // Add the input TP's contribution to the total ADC and add it to
-        // the TP list.
-        adc_integral += input_tp.adc_integral;
-        tp_list.push_back(input_tp);
-      };
+    
+      void add(TriggerPrimitive const &input_tp);
+
       void clear(){
         tp_list.clear();
       };
-      void move(TriggerPrimitive const &input_tp, timestamp_t const &window_length){
-        // Find all of the TPs in the window that need to be removed
-        // if the input_tp is to be added and the size of the window
-        // is to be conserved.
-        // Substract those TPs' contribution from the total window ADC.
-        uint32_t n_tps_to_erase = 0;
-        for(auto tp : tp_list){
-          if(!(input_tp.time_start-tp.time_start < window_length)){
-            n_tps_to_erase++;
-            adc_integral -= tp.adc_integral;
-          }
-          else break;
-        }
-        // Erase the TPs from the window.
-        tp_list.erase(tp_list.begin(), tp_list.begin()+n_tps_to_erase);
-        // Make the window start time the start time of what is now the
-        // first TP.
-        if(tp_list.size()!=0){
-          time_start = tp_list.front().time_start;
-          add(input_tp);
-        }
-        else reset(input_tp);
-      };
-      void reset(TriggerPrimitive const &input_tp){
-        // Empty the TP list.
-        tp_list.clear();
-        // Set the start time of the window to be the start time of the 
-        // input_tp.
-        time_start = input_tp.time_start;
-        // Start the total ADC integral.
-        adc_integral = input_tp.adc_integral;
-        // Add the input TP to the TP list.
-        tp_list.push_back(input_tp);
-      };
-      friend std::ostream& operator<<(std::ostream& os, const Window& window){
-        if(window.is_empty()) os << "Window is empty!\n";
-        else{
-          os << "Window start: " << window.time_start << ", end: " << window.tp_list.back().time_start;
-          os << ". Total of: " << window.adc_integral << " ADC counts with " << window.tp_list.size() << " TPs.\n"; 
-        }
-        return os;
-      };
+      
+      void move(TriggerPrimitive const &input_tp, timestamp_t const &window_length);
+
+      void reset(TriggerPrimitive const &input_tp);
 
       timestamp_t time_start;
       uint32_t adc_integral;
       std::deque<TriggerPrimitive> tp_list;
   };
+
+private:  
 
   TriggerActivity construct_ta() const;
 
@@ -95,6 +57,8 @@ private:
   uint32_t m_adc_threshold = 1200000;
   timestamp_t m_window_length = 100000;
 };
+
+
 } // namespace triggeralgs
 
 #endif // TRIGGERALGS_ADCSIMPLEWINDOW_TRIGGERACTIVITYMAKERADCSIMPLEWINDOW_HPP_

--- a/src/TAMakerADCSimpleWindowAlgorithm.cpp
+++ b/src/TAMakerADCSimpleWindowAlgorithm.cpp
@@ -86,6 +86,11 @@ TAMakerADCSimpleWindowAlgorithm::construct_ta() const
 
   const TriggerPrimitive& latest_tp_in_window = m_current_window.tp_list.back();
   uint64_t ch_min{latest_tp_in_window.channel}, ch_max{latest_tp_in_window.channel};
+  uint64_t time_max{latest_tp_in_window.time_start + latest_tp_in_window.samples_over_threshold * 32};
+
+  uint64_t adc_peak{latest_tp_in_window.adc_peak};
+  uint64_t ch_peak{dunedaq::trgdataformats::INVALID_CHANNEL};
+  timestamp_t time_peak{dunedaq::trgdataformats::INVALID_TIMESTAMP};
 
   std::vector<TriggerPrimitive> tp_list;
   tp_list.reserve(m_current_window.tp_list.size());
@@ -94,20 +99,26 @@ TAMakerADCSimpleWindowAlgorithm::construct_ta() const
     
     ch_min = std::min(ch_min, tp.channel);
     ch_max = std::max(ch_max, tp.channel);
+    time_max = std::max(time_max, tp.time_start + tp.samples_over_threshold * 32);
+    if (tp.adc_peak > adc_peak) {
+      adc_peak = tp.adc_peak;
+      ch_peak = tp.channel;
+      time_peak = time_peak;
+    }
 
     tp_list.push_back(tp);
   }
 
   TriggerActivity ta;
   ta.time_start = m_current_window.time_start;
-  ta.time_end = latest_tp_in_window.time_start + latest_tp_in_window.samples_over_threshold * 32;  // FIXME: Replace the hard-coded SOT to TOT scaling.
-  ta.time_peak = latest_tp_in_window.samples_to_peak * 32 + latest_tp_in_window.time_start;  // FIXME: Replace STP to `time_peak` conversion.
+  ta.time_end = time_max; 
+  ta.time_peak = time_peak;
   ta.time_activity = ta.time_peak;
   ta.channel_start = ch_min;
   ta.channel_end = ch_max;
-  ta.channel_peak = latest_tp_in_window.channel;
+  ta.channel_peak = ch_peak;
   ta.adc_integral = m_current_window.adc_integral;
-  ta.adc_peak = latest_tp_in_window.adc_peak;
+  ta.adc_peak = adc_peak;
   ta.detid = latest_tp_in_window.detid;
   ta.type = TriggerActivity::Type::kTPC;
   ta.algorithm = TriggerActivity::Algorithm::kADCSimpleWindow;

--- a/src/TAMakerADCSimpleWindowAlgorithm.cpp
+++ b/src/TAMakerADCSimpleWindowAlgorithm.cpp
@@ -157,11 +157,11 @@ TAMakerADCSimpleWindowAlgorithm::construct_ta() const
 
   const TriggerPrimitive& last_tp = m_current_window.tp_list.back();
   uint64_t ch_min{last_tp.channel}, ch_max{last_tp.channel};
-  uint64_t time_min{last_tp.time_start}, time_max{last_tp.time_start + last_tp.samples_over_threshold * 32};
+  uint64_t time_min{last_tp.time_start}, time_max{last_tp.time_start + last_tp.samples_over_threshold * k_sample_to_dts_ticks};
 
   uint64_t adc_peak{last_tp.adc_peak};
   uint64_t ch_peak{last_tp.channel};
-  timestamp_t time_peak{last_tp.time_start + last_tp.samples_to_peak * 32};
+  timestamp_t time_peak{last_tp.time_start + last_tp.samples_to_peak * k_sample_to_dts_ticks};
 
 
   std::vector<TriggerPrimitive> tp_list;
@@ -175,11 +175,11 @@ TAMakerADCSimpleWindowAlgorithm::construct_ta() const
     ch_min = std::min(ch_min, tp.channel);
     ch_max = std::max(ch_max, tp.channel);
     time_min = std::min(time_min, tp.time_start);
-    time_max = std::max(time_max, tp.time_start + tp.samples_over_threshold * 32);
+    time_max = std::max(time_max, tp.time_start + tp.samples_over_threshold * k_sample_to_dts_ticks); // FIXME: Replace the hard-coded SOT to TOT scaling.
     if (tp.adc_peak > adc_peak) {
       adc_peak = tp.adc_peak;
       ch_peak = tp.channel;
-      time_peak = tp.time_start + tp.samples_to_peak * 32;
+      time_peak = tp.time_start + tp.samples_to_peak * k_sample_to_dts_ticks; // FIXME: Replace the hard-coded STP to `time_peak` conversion.
     }
 
     tp_list.push_back(tp);

--- a/src/TAMakerADCSimpleWindowAlgorithm.cpp
+++ b/src/TAMakerADCSimpleWindowAlgorithm.cpp
@@ -14,11 +14,79 @@
 #include <vector>
 
 
-using namespace triggeralgs;
+
+
+namespace triggeralgs {
+
+// using namespace triggeralgs;
 using Logging::TLVL_DEBUG_ALL;
 using Logging::TLVL_DEBUG_HIGH;
 using Logging::TLVL_DEBUG_LOW;
 using Logging::TLVL_IMPORTANT;
+
+void
+TAMakerADCSimpleWindowAlgorithm::Window::add(TriggerPrimitive const &input_tp){
+  // Add the input TP's contribution to the total ADC and add it to
+  // the TP list.
+  adc_integral += input_tp.adc_integral;
+  tp_list.push_back(input_tp);
+};
+
+void 
+TAMakerADCSimpleWindowAlgorithm::Window::move(TriggerPrimitive const &input_tp, timestamp_t const &window_length){
+  // Find all of the TPs in the window that need to be removed
+  // if the input_tp is to be added and the size of the window
+  // is to be conserved.
+  // Substract those TPs' contribution from the total window ADC.
+  uint32_t n_tps_to_erase = 0;
+  for(auto tp : tp_list){
+    if(!(input_tp.time_start-tp.time_start < window_length)){
+      n_tps_to_erase++;
+      adc_integral -= tp.adc_integral;
+    }
+    else break;
+  }
+  // Erase the TPs from the window.
+  tp_list.erase(tp_list.begin(), tp_list.begin()+n_tps_to_erase);
+  // Make the window start time the start time of what is now the
+  // first TP.
+  if(tp_list.size()!=0){
+    time_start = tp_list.front().time_start;
+    add(input_tp);
+  }
+  else reset(input_tp);
+};
+
+
+void 
+TAMakerADCSimpleWindowAlgorithm::Window::reset(TriggerPrimitive const &input_tp){
+  // Empty the TP list.
+  tp_list.clear();
+  // Set the start time of the window to be the start time of the 
+  // input_tp.
+  time_start = input_tp.time_start;
+  // Start the total ADC integral.
+  adc_integral = input_tp.adc_integral;
+  // Add the input TP to the TP list.
+  tp_list.push_back(input_tp);
+};
+
+
+
+std::ostream& 
+operator<<(std::ostream& os, const TAMakerADCSimpleWindowAlgorithm::Window& window)
+{
+    if (window.is_empty()) {
+        os << "Window is empty!\n";
+    } else {
+        os << "Window start: " << window.time_start
+           << ", end: " << window.tp_list.back().time_start
+           << ". Total of: " << window.adc_integral
+           << " ADC counts with " << window.tp_list.size()
+           << " TPs.\n";
+    }
+    return os;
+}
 
 void
 TAMakerADCSimpleWindowAlgorithm::process(const TriggerPrimitive& input_tp, std::vector<TriggerActivity>& output_ta)
@@ -86,7 +154,7 @@ TAMakerADCSimpleWindowAlgorithm::construct_ta() const
 
   const TriggerPrimitive& latest_tp_in_window = m_current_window.tp_list.back();
   uint64_t ch_min{latest_tp_in_window.channel}, ch_max{latest_tp_in_window.channel};
-  uint64_t time_max{latest_tp_in_window.time_start + latest_tp_in_window.samples_over_threshold * 32};
+  uint64_t time_min{latest_tp_in_window.time_start}, time_max{latest_tp_in_window.time_start + latest_tp_in_window.samples_over_threshold * 32};
 
   uint64_t adc_peak{latest_tp_in_window.adc_peak};
   uint64_t ch_peak{dunedaq::trgdataformats::INVALID_CHANNEL};
@@ -95,10 +163,14 @@ TAMakerADCSimpleWindowAlgorithm::construct_ta() const
   std::vector<TriggerPrimitive> tp_list;
   tp_list.reserve(m_current_window.tp_list.size());
 
+
+  // Copy the queue into the vector
+  // And compute TA parameters
   for( const auto& tp : m_current_window.tp_list ) {
     
     ch_min = std::min(ch_min, tp.channel);
     ch_max = std::max(ch_max, tp.channel);
+    time_min = std::min(time_min, tp.time_start);
     time_max = std::max(time_max, tp.time_start + tp.samples_over_threshold * 32);
     if (tp.adc_peak > adc_peak) {
       adc_peak = tp.adc_peak;
@@ -110,10 +182,11 @@ TAMakerADCSimpleWindowAlgorithm::construct_ta() const
   }
 
   TriggerActivity ta;
-  ta.time_start = m_current_window.time_start;
+
+  ta.time_start = time_min;
   ta.time_end = time_max; 
   ta.time_peak = time_peak;
-  ta.time_activity = ta.time_peak;
+  ta.time_activity = time_peak;
   ta.channel_start = ch_min;
   ta.channel_end = ch_max;
   ta.channel_peak = ch_peak;
@@ -126,5 +199,8 @@ TAMakerADCSimpleWindowAlgorithm::construct_ta() const
   return ta;
 }
 
+
 // Register algo in TA Factory
 REGISTER_TRIGGER_ACTIVITY_MAKER(TRACE_NAME, TAMakerADCSimpleWindowAlgorithm)
+
+}

--- a/src/TAMakerADCSimpleWindowAlgorithm.cpp
+++ b/src/TAMakerADCSimpleWindowAlgorithm.cpp
@@ -30,7 +30,7 @@ TAMakerADCSimpleWindowAlgorithm::Window::add(TriggerPrimitive const &input_tp){
   // the TP list.
   adc_integral += input_tp.adc_integral;
   tp_list.push_back(input_tp);
-};
+}
 
 void 
 TAMakerADCSimpleWindowAlgorithm::Window::move(TriggerPrimitive const &input_tp, timestamp_t const &window_length){
@@ -40,22 +40,25 @@ TAMakerADCSimpleWindowAlgorithm::Window::move(TriggerPrimitive const &input_tp, 
   // Substract those TPs' contribution from the total window ADC.
   uint32_t n_tps_to_erase = 0;
   for(auto tp : tp_list){
-    if(!(input_tp.time_start-tp.time_start < window_length)){
+    if(input_tp.time_start-tp.time_start >= window_length){
       n_tps_to_erase++;
       adc_integral -= tp.adc_integral;
+    } else {
+      break;
     }
-    else break;
   }
   // Erase the TPs from the window.
   tp_list.erase(tp_list.begin(), tp_list.begin()+n_tps_to_erase);
+
   // Make the window start time the start time of what is now the
   // first TP.
-  if(tp_list.size()!=0){
+  if(!tp_list.empty()){
     time_start = tp_list.front().time_start;
     add(input_tp);
+  } else {
+    reset(input_tp);
   }
-  else reset(input_tp);
-};
+}
 
 
 void 
@@ -69,7 +72,7 @@ TAMakerADCSimpleWindowAlgorithm::Window::reset(TriggerPrimitive const &input_tp)
   adc_integral = input_tp.adc_integral;
   // Add the input TP to the TP list.
   tp_list.push_back(input_tp);
-};
+}
 
 
 
@@ -152,13 +155,14 @@ TAMakerADCSimpleWindowAlgorithm::construct_ta() const
   TLOG_DEBUG(TLVL_DEBUG_LOW) << "[TAM:ADCSW] I am constructing a trigger activity!";
   //TLOG_DEBUG(TRACE_NAME) << m_current_window;
 
-  const TriggerPrimitive& latest_tp_in_window = m_current_window.tp_list.back();
-  uint64_t ch_min{latest_tp_in_window.channel}, ch_max{latest_tp_in_window.channel};
-  uint64_t time_min{latest_tp_in_window.time_start}, time_max{latest_tp_in_window.time_start + latest_tp_in_window.samples_over_threshold * 32};
+  const TriggerPrimitive& last_tp = m_current_window.tp_list.back();
+  uint64_t ch_min{last_tp.channel}, ch_max{last_tp.channel};
+  uint64_t time_min{last_tp.time_start}, time_max{last_tp.time_start + last_tp.samples_over_threshold * 32};
 
-  uint64_t adc_peak{latest_tp_in_window.adc_peak};
-  uint64_t ch_peak{dunedaq::trgdataformats::INVALID_CHANNEL};
-  timestamp_t time_peak{dunedaq::trgdataformats::INVALID_TIMESTAMP};
+  uint64_t adc_peak{last_tp.adc_peak};
+  uint64_t ch_peak{last_tp.channel};
+  timestamp_t time_peak{last_tp.time_start + last_tp.samples_to_peak * 32};
+
 
   std::vector<TriggerPrimitive> tp_list;
   tp_list.reserve(m_current_window.tp_list.size());
@@ -175,7 +179,7 @@ TAMakerADCSimpleWindowAlgorithm::construct_ta() const
     if (tp.adc_peak > adc_peak) {
       adc_peak = tp.adc_peak;
       ch_peak = tp.channel;
-      time_peak = time_peak;
+      time_peak = tp.time_start + tp.samples_to_peak * 32;
     }
 
     tp_list.push_back(tp);
@@ -192,7 +196,7 @@ TAMakerADCSimpleWindowAlgorithm::construct_ta() const
   ta.channel_peak = ch_peak;
   ta.adc_integral = m_current_window.adc_integral;
   ta.adc_peak = adc_peak;
-  ta.detid = latest_tp_in_window.detid;
+  ta.detid = last_tp.detid;
   ta.type = TriggerActivity::Type::kTPC;
   ta.algorithm = TriggerActivity::Algorithm::kADCSimpleWindow;
   ta.inputs.swap(tp_list);

--- a/src/TAMakerADCSimpleWindowAlgorithm.cpp
+++ b/src/TAMakerADCSimpleWindowAlgorithm.cpp
@@ -84,23 +84,34 @@ TAMakerADCSimpleWindowAlgorithm::construct_ta() const
   TLOG_DEBUG(TLVL_DEBUG_LOW) << "[TAM:ADCSW] I am constructing a trigger activity!";
   //TLOG_DEBUG(TRACE_NAME) << m_current_window;
 
-  TriggerPrimitive latest_tp_in_window = m_current_window.tp_list.back();
-  // The time_peak, time_activity, channel_* and adc_peak fields of this TA are irrelevent
-  // for the purpose of this trigger alg.
+  const TriggerPrimitive& latest_tp_in_window = m_current_window.tp_list.back();
+  uint64_t ch_min{latest_tp_in_window.channel}, ch_max{latest_tp_in_window.channel};
+
+  std::vector<TriggerPrimitive> tp_list;
+  tp_list.reserve(m_current_window.tp_list.size());
+
+  for( const auto& tp : m_current_window.tp_list ) {
+    
+    ch_min = std::min(ch_min, tp.channel);
+    ch_max = std::max(ch_max, tp.channel);
+
+    tp_list.push_back(tp);
+  }
+
   TriggerActivity ta;
   ta.time_start = m_current_window.time_start;
   ta.time_end = latest_tp_in_window.time_start + latest_tp_in_window.samples_over_threshold * 32;  // FIXME: Replace the hard-coded SOT to TOT scaling.
   ta.time_peak = latest_tp_in_window.samples_to_peak * 32 + latest_tp_in_window.time_start;  // FIXME: Replace STP to `time_peak` conversion.
   ta.time_activity = ta.time_peak;
-  ta.channel_start = latest_tp_in_window.channel;
-  ta.channel_end = latest_tp_in_window.channel;
+  ta.channel_start = ch_min;
+  ta.channel_end = ch_max;
   ta.channel_peak = latest_tp_in_window.channel;
   ta.adc_integral = m_current_window.adc_integral;
   ta.adc_peak = latest_tp_in_window.adc_peak;
   ta.detid = latest_tp_in_window.detid;
   ta.type = TriggerActivity::Type::kTPC;
   ta.algorithm = TriggerActivity::Algorithm::kADCSimpleWindow;
-  ta.inputs = m_current_window.tp_list;
+  ta.inputs.swap(tp_list);
   return ta;
 }
 


### PR DESCRIPTION
# Description

See issue https://github.com/DUNE-DAQ/triggeralgs/issues/84

Additionally, this PR moves the window buffer implementation from vector to deque

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

