### PR TITLE
Johnfreeman/trgdataformats issue59 review impl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(triggeralgs VERSION 1.6.0)
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 add_compile_options(-O2 -flto)

--- a/README.md
+++ b/README.md
@@ -158,3 +158,59 @@ contains a readout request (i.e. you MUST trigger), based on all the candidates 
 | `algorithm`      | `uint32_t`                      | some flag that says which algorithm created it (although I think there will only ever be one of this) |
 | `version`        | `uint16_t`                      | version of above                                                                                      |
 | `tc_list`        | `std::vector<TriggerCandidate>` | the list of TCs that was used to create it                                                            |
+
+You'll notice from looking at the code that the metadata components of
+`TriggerPrimitive`, `TriggerActivity` and `TriggerCandidate` (time,
+etc.) are all taken from structs in the `trgdataformats`
+package. There's a close relationship between this package and
+`trgdataformats`, which you'll see more of below.
+
+### Converting to and from overlays
+
+For serialization purposes, `trgdataformats` contains overlay classes
+for trigger primitives, trigger activity and trigger candidate
+objects, and `triggeralgs` provides tools to convert between their
+`triggeralgs` representation to/from those overlay classes.
+
+To convert a TA or TC into its corresponding overlay class and write
+it into a buffer, first find the required buffer size using
+`get_overlay_nbytes()`, passing the `TriggerActivity` or
+`TriggerCandidate` as an argument. With a buffer of the correct size,
+the overlay class can be written using `write_overlay(object,
+buffer)`. To read the overlay object from the buffer, you use
+`reinterpret_cast`. A simple example application:
+
+```c++
+
+#include "triggeralgs/TriggerCandidate.hpp"
+#include "triggeralgs/TriggerObjectOverlay.hpp"
+
+#include "trgdataformats/TriggerObjectOverlay.hpp"
+
+#include <cstddef>
+#include <vector>
+
+int main() {
+
+  triggeralgs::TriggerCandidate candidate;
+
+  // ...Set fields to some values...
+
+  // Find the required buffer size
+  size_t nbytes = triggeralgs::get_overlay_nbytes(candidate);
+
+  // Create a buffer of the appropriate size
+  std::vector<std::byte> buffervec(nbytes);
+  
+  // Write the `candidate` object as trgdataformats' TriggerCandidate into `buffer`
+  triggeralgs::write_overlay(candidate, buffervec.data());
+
+  // Can recover the trgdataformats' TriggerCandidate from the buffer
+  const dunedaq::trgdataformats::TriggerCandidate& candidate_overlay =
+    *reinterpret_cast<const dunedaq::trgdataformats::TriggerCandidate*>(buffervec.data());
+
+  // Can convert back to triggeralgs::TriggerCandidate
+  triggeralgs::TriggerCandidate candidate_read = triggeralgs::read_overlay_from_buffer<triggeralgs::TriggerCandidate>(buffervec.data());
+
+}
+```

--- a/include/triggeralgs/TriggerObjectOverlay.hpp
+++ b/include/triggeralgs/TriggerObjectOverlay.hpp
@@ -55,10 +55,7 @@ write_overlay(const Object& object, void* buffer)
 {
   Overlay* overlay = reinterpret_cast<Overlay*>(buffer);
   overlay->data = static_cast<Data>(object);
-  overlay->n_inputs = object.inputs.size();
-  for (size_t i = 0; i < object.inputs.size(); ++i) {
-    overlay->inputs[i] = object.inputs[i];
-  }
+  overlay->set_inputs(object.inputs);
 }
 
 // Calculate the size of buffer (in bytes) required to store an

--- a/src/TCMakerProtoDUNEBSMWindowAlgorithm.cpp
+++ b/src/TCMakerProtoDUNEBSMWindowAlgorithm.cpp
@@ -27,7 +27,7 @@ void TCMakerProtoDUNEBSMWindowAlgorithm::process(const TriggerActivity& activity
   std::vector<TriggerActivity::TriggerActivityData> ta_list = {static_cast<TriggerActivity::TriggerActivityData>(activity)};
 
   TLOG_DEBUG(TLVL_DEBUG_LOW) << "[TCM:ADCSW] Emitting an "
-                             << dunedaq::trgdataformats::get_trigger_candidate_type_names()[m_tc_type]
+                             << dunedaq::trgdataformats::trigger_candidate_type_to_string(m_tc_type)
                              << " TriggerCandidate with AEAnomalyWindow algorithm" << (m_activity_count-1);
 
   TriggerCandidate tc;

--- a/src/TCMakerSupernovaAlgorithm.cpp
+++ b/src/TCMakerSupernovaAlgorithm.cpp
@@ -24,7 +24,7 @@ TCMakerSupernovaAlgorithm::process(const TriggerActivity& activity, std::vector<
   // Yay! we have a trigger!
   if (m_activity.size() > m_threshold) {
 
-    detid_t detid = dunedaq::trgdataformats::WHOLE_DETECTOR;
+    detid_t detid = dunedaq::trgdataformats::g_whole_detector;
 
     TriggerCandidate tc;
     tc.time_start = time - 500'000'000; // time_start (10 seconds before the start of the activity)


### PR DESCRIPTION
# Description

This is a change needed so this repo compiles against the updates to `trgdataformats` in https://github.com/DUNE-DAQ/trgdataformats/pull/61. It should not be merged before the `trgdataformats` PR is merged. As `trgdataformats` will now include code which compiles under C++20 and not C++17, for `triggeralgs` to compile its standard will also need to be bumped to C++20. 

A successful test build (`TDFRFD_DEV_260811_A9`, https://github.com/DUNE-DAQ/daq-release/actions/runs/31514886523) was performed using this branch.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [X ] Unit tests pass (e.g. `dbt-build --unittest`)
- [X ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [X ] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

