### PR TITLE
wrk: version v1.7.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.13)
-project(triggeralgs VERSION 1.6.0)
+project(triggeralgs VERSION 1.7.0)
 
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)


### PR DESCRIPTION
# Description

This PR bumps `triggeralgs` from **v1.6.0** to **v1.7.0** in support of the **fddaq-v5.7.0** build.

Reference tag: `v1.7.0` (already pushed, points at this branch's tip commit)
Commits in this PR: 1 (`wrk: bump version to v1.7.0`)

**Impact Radius / Change classification:** MINOR
- New SWIFT TAMaker trigger-activity algorithm added.
- Internal `ProtoDUNEBSMWindow` refactor, including removal of some public header methods; believed to have no external consumers.

## Version-file diff

```diff
diff --git a/CMakeLists.txt b/CMakeLists.txt
index 1f37241..afb23f6 100644
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.13)
-project(triggeralgs VERSION 1.6.0)
+project(triggeralgs VERSION 1.7.0)
 
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)
```

> [!IMPORTANT]
> Tag `v1.7.0` has already been pushed and points at the head commit of this
> branch. **Please merge this PR with a merge commit — do not squash or rebase.**
> Squashing or rebasing would leave the published tag pointing at a commit that
> is not an ancestor of `develop`.

## Type of change

- [x] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_This is an automated version-bump PR; no test execution was performed by this agent._

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))
